### PR TITLE
Use http for fetching git-repositories with npm instead of ssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/telefonicaid/iotagent-json.git"
+    "url": "https://github.com/telefonicaid/iotagent-json.git"
   },
   "bugs": {
     "url": "https://github.com/telefonicaid/iotagent-json/issues"
@@ -52,7 +52,7 @@
     "body-parser": "1.15.0",
     "dateformat": "1.0.12",
     "amqplib": "^0.5.1",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "1.0.0-alpha.7",
     "mqtt": "1.7.0",
     "request": "^2.69.0",


### PR DESCRIPTION
https tends to work better in dockered environments.
Building the docker-container would otherwise require some ssh-key/trust acrobatics. 