### PR TITLE
Clarified North/South, removed anchors, added code highlights

### DIFF
--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -6,7 +6,7 @@
 * [Configuration](#configuration)
 * [Packaging](#packaging)
 
-### <a name="installation"/> Installation
+### Installation
 There are two ways of installing the JSON IoT Agent: using Git or RPMs.
 
 #### Using GIT
@@ -38,7 +38,7 @@ The IoTA will then be installed as a linux service, and can ve started with the 
 ```
 service iotaJSON start
 ```
-### <a name="usage"/> Usage
+### Usage
 In order to execute the JSON IoT Agent just execute the following command from the root folder:
 ```
 bin/iotagentMqtt.js
@@ -49,12 +49,12 @@ When started with no arguments, the IoT Agent will expect to find a `config.js` 
 folder. An argument can be passed with the path to a new configuration file (relative to the application folder) to be
 used instead of the default one.
 
-### <a name="configuration"/> Configuration
+### Configuration
 #### Overview
 All the configuration for the IoT Agent is stored in a single configuration file (typically installed in the root folder).
 
 This configuration file is a JavaScript file and contains three configuration chapters:
-* **iota**: this object stores the configuration of the Northbound of the IoT Agent, and is completely managed by the
+* **iota**: this object stores the configuration of the North Port of the IoT Agent, and is completely managed by the
 IoT Agent library. More information about this options can be found [here](https://github.com/telefonicaid/iotagent-node-lib#configuration).
 * **mqtt**: this object stores MQTT's specific configuration. A detailed description can be found in the next section.
 * **http**: this object stores HTTP's specific configuration. A detailed description can be found in the next section.

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -1,10 +1,10 @@
 # Installation & Administration Guide
 
 ## Index
+
 * [Installation](#installation)
 * [Usage](#usage)
 * [Configuration](#configuration)
-* [Packaging](#packaging)
 
 ### Installation
 There are two ways of installing the JSON IoT Agent: using Git or RPMs.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,7 +4,7 @@
 * [Overview](#overview)
 * [Logs](#logs)
 * [Alarms](#alarms)
-* [Error naming code](#errorcode)
+* [Error naming code](#error-naming-code)
 
 
 ## Overview
@@ -77,8 +77,8 @@ The received MQTT message did not contain a valid JSON payload. This will usuall
 side: either the JSON itself is not well-formed, or it has been encoded in a way the IoTAgent was not able to decode.
 
 #### MEASURES-004: Device not found for topic [%s]
-This error log will appear whenever a measure arrives to the IoTAgent for a device that has not been provisioned or for
-an API Key that has not been registered in the IOTAgent. This could have several origins: the may be a typo in the
+This error log will appear whenever a measure arrives to the IoT Agent for a device that has not been provisioned or for
+an API Key that has not been registered in the IoT Agent. This could have several origins: the may be a typo in the
 DeviceId or APIKey used by the customer; or either the Configuration or the Device for the corresponding measure may
 have been removed; or the customer may have forgotten to provision both the Configuration and the Device.
 
@@ -91,7 +91,7 @@ client itself.
 
 #### GLOBAL-001: Error subscribing to topics: %s
 Error subscribing the IoT Agent to the appropriate MQTT Topics. This error can only happen at startup time, and should
-prevent the IOTA from starting. If this error occurs, check the Mosquitto MQTT broker is up and running and check the
+prevent the IoT Agent from starting. If this error occurs, check the Mosquitto MQTT broker is up and running and check the
 connectivity from the IoTAgent to the broker.
 
 #### GLOBAL-002: Configuration error. Configuration object [config.http] is missing

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,11 +7,11 @@
 * [Error naming code](#errorcode)
 
 
-## <a name="overview"/>  Overview
+## Overview
 The following document shows all the errors that can appear in the IoTAgent Ultralight 2.0 log file, and gives a brief
 idea of the severity and how to react to those errors.
 
-## <a name="logs"/>  Logs
+## Logs
 The following section contains the error log entries that can appear in the IoTA logs, grouped by category.
 
 ### Command errors
@@ -99,7 +99,7 @@ connectivity from the IoTAgent to the broker.
 Indicates the mandatory "config.http" configuration parameter was not found while starting the IoTAgent. This will
 prevent the IoTAgent from starting. Check the configuration files and fix them to be valid.
 
-## <a name="alarms"/> Alarms
+## Alarms
 
 The following table shows the alarms that can be raised in the JSON IoTAgent library. All the alarms are signaled by an
 error log starting with the prefix "Raising [%s]:" (where %s is the alarm name). All the alarms are released by an info
@@ -115,7 +115,7 @@ while the 'Severity' criterium is as follows:
 * **Major** - The system has a problem that degrades the service and must be addressed
 * **Warning** - It is happening something that must be notified
 
-## <a name="errorcode"/> Error naming code
+## Error naming code
 Every error has a code composed of a prefix and an ID, codified with the following table:
 
 | Prefix           | Type of operation      |

--- a/docs/stepbystep.md
+++ b/docs/stepbystep.md
@@ -174,8 +174,8 @@ mosquitto_pub -h <mosquittoIp> -t /<apiKey>/<devId>/attrs -m '{"L":4,"T": "31.5"
 If you execute both commands in different windows, when you run the latter command, you should see the string `{"L":4,"T": "31.5","H":30}`
 appearing in the former.
 
-This tutorial will use mainly the mosquitto clients and curl commands, to give a detailed view of how the APIs (
-NGSI traffic north of the IoT Agent and JSON south of the IoT Agent). Whenever a command is needed, the exact command to be executed will be given.
+This tutorial will use mainly the mosquitto clients and curl commands, to give a detailed view of how the APIs -
+NGSI traffic north of the IoT Agent and MQTT (with a JSON payload) south of the IoT Agent. Whenever a command is needed, the exact command to be executed will be given.
 
 ### Provisioning the device
 

--- a/docs/stepbystep.md
+++ b/docs/stepbystep.md
@@ -8,13 +8,13 @@ Step by Step guide
 * [Provisioning multiple devices with a Configuration](#withconfiguration)
 * [Using ACLs to secure provisioning access](#acls)
 
-## <a name="introduction">Introduction</a>
+## Introduction
 
 This guide will show, step-by-step, how to deploy and configure an MQTT-JSON IoT Agent for its use to connect devices
 to an external NGSI Broker (aka Context Broker).
 
 The MQTT-JSON IoT Agent acts as a gateway for communicating devices using the MQTT protocol with NGSI brokers (or any
-other piece which uses the NGSI protocol). The communication is based on a series of unidirectional MQTT topics 
+other piece which uses the NGSI protocol). The communication is based on a series of unidirectional MQTT topics
 (i.e.: each topic is used to *publish* device information or to *subscribe* to entity updates, but not both). Every
 topic has the same prefix, of the form:
 ```
@@ -23,7 +23,7 @@ topic has the same prefix, of the form:
 
 Where `apiKey` is an alphanumerical string used to group devices logically (and for security matters) and `deviceId` is
 an ID that uniquely identifies the device. The API Key can be configured globally for an instance of the IoT Agent, or
-specifically for a given group of devices (as will be explained in the following sections). 
+specifically for a given group of devices (as will be explained in the following sections).
 
 A detailed specification of the protocol can be found [here](usermanual.md).
 
@@ -40,13 +40,13 @@ data, simulating a Smart Home application:
 * *DevId*: sensor01, sensor02 and actuator01
 
 ### Prerequisites
-This step-by-step guide assumes you are going to install all the software in a single machine, with a Red Hat 6.5 
+This step-by-step guide assumes you are going to install all the software in a single machine, with a Red Hat 6.5
 Linux installation. As such, it may not be an appropriate architecture for production purposes, but it should
 serve as a development machine to test the MQTT IoT Agent. All the commands are meant to be executed from the same
 machine (even curls and mosquitto-pub commands), but changing them to execute them from an external machine should be
 a trivial task.
 
-The selected MQTT Broker for this tutorial was Mosquitto, although it could be substituted by any other standard 
+The selected MQTT Broker for this tutorial was Mosquitto, although it could be substituted by any other standard
 MQTT broker. The Mosquitto command tools will also be used along this guide to test the installation and show the
 information interchanged between simulated devices and the Context Broker.
 
@@ -64,48 +64,55 @@ work as well (previous versions could also work, but also may not, so we encoura
 To enhance readability all the commands will be executed as root. To use other users, give it the appropriate permissions
 and use `sudo` as usual (installation from the RPM package creates a special user for the agent, but it will not be
 used along this tutorial).
- 
-## <a name="singledevice">Provisioning a single device with the default API Key</a>
+
+## Provisioning a single device with the default API Key
 
 ### Installing the IoT Agent
-There are different ways to install the IoT Agent. In this tutorial, we will clone the last version of the agent from 
+There are different ways to install the IoT Agent. In this tutorial, we will clone the last version of the agent from
 the repository. For different setups, check the installation guide in the main `README.md` file.
- 
+
 We will install our IoT Agent in the '/opt'  repository. To do so, go to the folder and clone the repository with the
 following commands:
-```
+
+```bash
 cd /opt
 git clone https://github.com/telefonicaid/iotagent-json.git
 ```
 
 Now the repository has been cloned, enter the new directory and install the dependencies, with the following commands:
-```
+
+```bash
 cd iotagent-json
 npm install
 ```
 
 Now, run the agent in the background executing:
-```
+
+```bash
 nohup bin/iotagent-json &> /var/log/iotAgent&
 ```
 
-The agent should be now listening in the northbound port (defaults to 4041). Check it with a netstat command:
-```
+The agent should be now listening in the North Port (defaults to 4041). Check it with a netstat command:
+
+```bash
 netstat -ntpl | grep 4041
 ```
 
 You should see an output like this:
+
 ```
-tcp        0      0 0.0.0.0:4041                0.0.0.0:*                   LISTEN      18388/node 
+tcp        0      0 0.0.0.0:4041                0.0.0.0:*                   LISTEN      18388/node
 ```
 
-An easy way to see everything is working is to get the version from the north bound API:
-```
+An easy way to see everything is working is to get the version from the North Port of the IoT Agent:
+
+```bash
 curl http://localhost:4041/iot/about
 ```
 
 The result will be a JSON document indicating the MQTT-JSON IoTA version and the version of the IoTA Library in use:
-```
+
+```json
 {
   "libVersion":"0.9.5",
   "port":4041,
@@ -119,7 +126,7 @@ You can also check the logs in the `/var/log/iotAgent` file created with the noh
 ### IoT Agent configuration
 
 All the configuration of the IoTAgent can be done modifying a single file, `config.js`. The default values should meet
-the needs of this tutorial. 
+the needs of this tutorial.
 
 For a detailed description of these values, check the [iotagent-node-lib configuration documentation](https://github.com/telefonicaid/iotagent-node-lib/blob/master/doc/installationguide.md).
 
@@ -127,7 +134,7 @@ There is a configuration value that you may want to change while following this 
 you have any problems following the instructions, or you simply want to know more of what's going on in the IoTA internals,
 set its value to `DEBUG`.
 
-Also note that the configuration type of the `deviceRegistry` is set to `memory`. This means all the contents of the 
+Also note that the configuration type of the `deviceRegistry` is set to `memory`. This means all the contents of the
 Device Registry will be wiped out from memory when the IoTAgent restarts. This is meant to be used in testing environments
 and it will force you to provision again all your devices once you have restarted the agent. For persistent registries,
 check the documentation to see how to connect the IoTA to a MongoDB instance.
@@ -136,51 +143,55 @@ check the documentation to see how to connect the IoTA to a MongoDB instance.
 
 The IoT Agent comes with a command-line client that can be used for an initial testing of the installation. This client
 offers commands to simulate MQTT requests with measures, device and configuration provisioning requests and NGSI queries
-to the Context Broker, that can be used to test the results. 
+to the Context Broker, that can be used to test the results.
 
 In order to start the command line client, just type:
-```
+
+```bash
 bin/iotaJsonTester.js
 ```
 
 You can type `help` for a brief description of the full list of commands.
 
-Mosquitto also comes along with two command-line utilities that can be used to test the MQTT south-bound of the IoTA. 
+Mosquitto also comes along with two command-line utilities that can be used to test the MQTT south-bound of the IoTA.
 
 Mosquitto-sub can be used to subscribe to a certain topic, showing all the information sent to the topic in the console
 output. To subscribe to a topic, use:
-```
+
+```bash
 mosquitto_sub -h <mosquittoIp> -t /<apiKey>/<devId>/attrs
 ```
 
-Where <mosquittoIp> is the IP where your instance of the Mosquitto broker is listening and <apiKey> and <devId> depend 
+Where <mosquittoIp> is the IP where your instance of the Mosquitto broker is listening and <apiKey> and <devId> depend
 on the device you are using. You can omit the `-h` parameter if working on localhost.
 
 Mosquitto-pub can be used to send information to a topic. This will be a typical execution example:
-```
+
+```bash
 mosquitto_pub -h <mosquittoIp> -t /<apiKey>/<devId>/attrs -m '{"L":4,"T": "31.5","H":30}'
 ```
 
 If you execute both commands in different windows, when you run the latter command, you should see the string `{"L":4,"T": "31.5","H":30}`
 appearing in the former.
 
-This tutorial will use mainly the mosquitto clients and curl commands, to give a detailed view of how the APIs (both 
-northbound and southbound work). Whenever a command is needed, the exact command to be executed will be given.
+This tutorial will use mainly the mosquitto clients and curl commands, to give a detailed view of how the APIs (
+NGSI traffic north of the IoT Agent and JSON south of the IoT Agent). Whenever a command is needed, the exact command to be executed will be given.
 
 ### Provisioning the device
 
 In order to start using the IoTA, a new device must be provisioned. We will use curl commands to create it. Execute the
 following command:
-```
-curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{ 
-    "devices": [ 
-        { 
-            "device_id": "sensor01", 
-            "entity_name": "LivingRoomSensor", 
-            "entity_type": "multiSensor", 
-            "attributes": [ 
+
+```bash
+curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
+    "devices": [
+        {
+            "device_id": "sensor01",
+            "entity_name": "LivingRoomSensor",
+            "entity_type": "multiSensor",
+            "attributes": [
                   { "object_id": "t", "name": "Temperature", "type": "celsius" },
-                  { "object_id": "l", "name": "Luminosity", "type": "lumens" }                  
+                  { "object_id": "l", "name": "Luminosity", "type": "lumens" }
             ]
         }
     ]
@@ -188,22 +199,25 @@ curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -
 
 ' 'http://localhost:4041/iot/devices'
 ```
+
 This command will create the simplest kind of device, with just two declared active attributes: Temperature and Luminosity.
 
-We have not created a specific configuration for our devices yet, so *the API Key will be the default one* for the IoTA 
+We have not created a specific configuration for our devices yet, so *the API Key will be the default one* for the IoTA
 (i.e.: 1234). This default API Key can be changed in the config file.
 
 ### Sending measures with the device
 
 Now we can simulate some measures from the device. Since our device has DeviceID `sensor01` and the API Key we are using
 is the default one, `1234`, we can send a measure with the mosquitto command line client using the following command:
-```
+
+```bash
 mosquitto_pub -t /1234/sensor01/attrs -m '{"l":4,"t": "31.5"}'
 ```
 
 This command should publish all the information in the Context Broker. A queryContext operation over the device entity
 should give us the published information:
-```
+
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -d '{
     "entities": [
         {
@@ -216,7 +230,8 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
 ```
 
 The resulting response should look like the following:
-```
+
+```json
 {
   "contextResponses" : [
     {
@@ -253,28 +268,32 @@ purposes. This mechanism is based on two special topics, with suffix `/configura
 
 In order to test this functionality, we will, first of all, add some configuration attributes to the Context Broker entity
 representing the device. We will add the `sleepTime` attribute with the following NGSI request:
-```
+
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -H "Cache-Control: no-cache" -d '{
 "value" : "300"
 }' 'http://localhost:1026/v1/contextEntities/LivingRoomSensor/attributes/sleepTime'
 ```
 
 When the IoTAgent is asked for configuration values, it will ask the Context Broker for those values. Once it has collected
-them, it will send them to the device in the topic with suffix '/configuration/values'. To check this operation with our 
+them, it will send them to the device in the topic with suffix '/configuration/values'. To check this operation with our
 simulated device, execute the following line:
-```
+
+```bash
 mosquitto_sub -t /1234/sensor01/configuration/values
 ```
 
 Leave this command in a separate window while you execute the following steps.
 
 Now we can ask the IoT Agent for the attribute value sending an MQTT request like the following one:
-```
+
+```bash
 mosquitto_pub -t /1234/sensor01/configuration/commands -m '{ "type": "configuration", "fields": [ "sleepTime" ] }'
 ```
 
 If we return now to the subscription window, we should be able to see the value of the `sleepTime` command:
-```
+
+```json
 {"sleepTime":"300","dt":"20160209T111442Z"}
 ```
 
@@ -284,8 +303,8 @@ the response.
 ## <a name="withconfiguration">Provisioning multiple devices with a Configuration</a>
 
 In those cases where a group of devices with similar characteristics will be provisioned, a common configuration can be
-created for them. This configuration provision can be used to separate device messages between services, by 
-establishing a specific API Key for each group. This can be used to secure access for specific groups of devices (an 
+created for them. This configuration provision can be used to separate device messages between services, by
+establishing a specific API Key for each group. This can be used to secure access for specific groups of devices (an
 example of how to do that will be shown in the last section for the Mosquitto MQTT broker).
 
 ### Provisioning the configuration
@@ -293,9 +312,9 @@ example of how to do that will be shown in the last section for the Mosquitto MQ
 First of all, we will provision a new configuration with the data we defined in the introduction section. In order to do
 that, we will issue the following command:
 
-```
-curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{ 
-    "services": [ 
+```bash
+curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
+    "services": [
       {
           "resource": "",
           "apikey": "AAFF9977",
@@ -308,7 +327,7 @@ curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -
 ```
 
 This will make devices provisioned for that service, subservice and type use the provided APIKey as its APIKey prefix
-in the MQTT topics. As you can see, the `resource` field is left blank (this IoT Agent doesn't make use of this field, 
+in the MQTT topics. As you can see, the `resource` field is left blank (this IoT Agent doesn't make use of this field,
 but it's a mandatory attribute in the API, so it should always be sent with the empty string).
 
 ### Provisioning the device
@@ -317,12 +336,12 @@ For IoT Agents that support automatic device provisioning, provisioning a config
 that use that configuration. For those who don't, each specific device must be provisioned, in order to save its deviceID
 in the Device Registry. The provision of the device is quite similar to the one of the single device:
 
-```
-curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{ 
-    "devices": [ 
-        { 
-            "device_id": "sensor02", 
-            "entity_name": "RosesPot", 
+```bash
+curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
+    "devices": [
+        {
+            "device_id": "sensor02",
+            "entity_name": "RosesPot",
             "entity_type": "potSensor",
             "attributes": [
               {
@@ -345,7 +364,8 @@ curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -
 
 Now we can simulate a measure as in the case of the single device provision. Use the following command to send a new
 simulated measure:
-```
+
+```bash
 mosquitto_pub -t /AAFF9977/sensor02/attrs -m '{"humidity": 76,"happiness": "Not bad"}'
 ```
 
@@ -365,7 +385,8 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
 ```
 
 We will get something like this:
-```
+
+```bash
 {
   "contextResponses" : [
     {
@@ -397,15 +418,15 @@ We will get something like this:
 
 That shows the information we sent with the measures has been written to the Context Broker properly.
 
-## <a name="acls">Using ACLs to secure provisioning access</a>
+## Using ACLs to secure provisioning access
 
 ### Overview
 The use of special APIKeys gives the IoTAgent administrator the opportunity to set different MQTT-Broker level permissions
-for each group of devices, using different authorization mechanisms to sepparate access between groups. 
+for each group of devices, using different authorization mechanisms to sepparate access between groups.
 
-With the plain out-of-the-box Mosquitto setup, any device (any MQTT client, in fact) can send information impersonating 
-other devices or read the information in their entities, just knowing their API-Key and deviceId. To avoid this problem, 
-we will create an ACL that will give special permissions for our Configuration, and a set of credentials for the devices 
+With the plain out-of-the-box Mosquitto setup, any device (any MQTT client, in fact) can send information impersonating
+other devices or read the information in their entities, just knowing their API-Key and deviceId. To avoid this problem,
+we will create an ACL that will give special permissions for our Configuration, and a set of credentials for the devices
 of the group (that should be secretly shared with the devices). To make it simple, we will use a set of user and password
 credentials, the same for all the devices of the group (other means of authentication could have been used instead, as
 certificates, check Mosquitto documentation for other options).
@@ -416,7 +437,8 @@ anonymous by default). To protect the interactions for the IoTA, another user wi
 ### Configuration
 
 In order to create the users, we will use the password tool provided by mosquitto. Execute the following commands:
-```
+
+```bash
 touch /etc/mosquitto/pwfile
 mosquitto_passwd -b /etc/mosquitto/pwfile iota iota
 mosquitto_passwd -b /etc/mosquitto/pwfile potteduser pottedpass
@@ -424,8 +446,9 @@ mosquitto_passwd -b /etc/mosquitto/pwfile potteduser pottedpass
 
 This will create two sets of credentials (login/password): iota/iota and potteduser/pottedpass.
 
-The permissions for different topics can be given with ACL files. To create one, just create a new `/etc/mosquitto/aclfile` 
+The permissions for different topics can be given with ACL files. To create one, just create a new `/etc/mosquitto/aclfile`
 file with the following contents:
+
 ```
 topic read $SYS/#
 
@@ -454,15 +477,16 @@ There are three sections of interest in this file:
  IoT Agent, but this doesn't forbid one device impersonating others. This access is anonymous.
 
 * An authenticated `iota` user can access everything, as it is supposed to be the owner of the broker (and just administrators
-should have access to this user). 
+should have access to this user).
 
 * For the `potteduser` account, the permissions are similar to those of the anonymous devices, but with a different APIKey
  as the prefix. This ensures that no device coming from other group (that is supposed not to have valid credentials as
  `potteduser`) will impersonate a device of the group, or subscribe to information sent by the group devices.
- 
+
 There are two more changes needed before we restart our test. First of all, we should add the IoTA Mosquitto credentials
 to the IoTA Configuration, to give it full access to the MQTT Broker topics. To do so, edit the `/opt/iotajson/config.js`
  file and change the `config.mqtt` section to look like this:
+
 ```
 config.mqtt = {
     host: 'localhost',
@@ -473,9 +497,10 @@ config.mqtt = {
 };
 ```
 
-The last action to take is to edit the `/etc/mosquitto/mosquitto.conf` to add the `aclfile` and `pwfile` files to the 
+The last action to take is to edit the `/etc/mosquitto/mosquitto.conf` to add the `aclfile` and `pwfile` files to the
 configuration. The finished configuration should be something like this:
-```
+
+```bash
 pid_file /var/run/mosquitto.pid
 
 persistence true
@@ -489,7 +514,8 @@ include_dir /etc/mosquitto/conf.d
 ```
 
 Now that all the changes have been completed, restart mosquitto:
-```
+
+```bash
 service mosquitto restart
 ```
 
@@ -503,16 +529,17 @@ but using a different device, with data:
 
  * *Name*: DaisyPot
  * *DevId*: sensor03
- 
+
 It's important that you provision the configuration with the exact same APIKey you declared in the ACL.
 
 The device provisioning request will be the following:
-```
-curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{ 
-    "devices": [ 
-        { 
-            "device_id": "sensor03", 
-            "entity_name": "DaisyPot", 
+
+```bash
+curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '{
+    "devices": [
+        {
+            "device_id": "sensor03",
+            "entity_name": "DaisyPot",
             "entity_type": "potSensor",
             "attributes": [
               {
@@ -540,7 +567,8 @@ mosquitto_pub -t /AAFF9977/sensor03/attrs -m '{"humidity": 76,"happiness": "Not 
 
 If we use a queryContext to check if the changes have been progressed to the Context Broker we will find that those
 measures have been ignored:
-```
+
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -d '{
     "entities": [
         {
@@ -555,12 +583,14 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
 Checking the IoTAgent logs you will see that the request was completely ignored. The problem was that the client was
 trying to make an anonymous publish in a ACL protected topic that let only the user `potteduser`publish new messages.
 If we try again using the credentials we generated for the user:
-```
+
+```bash
 mosquitto_pub -t /AAFF9977/sensor03/attrs -m '{"humidity": 76,"happiness": "Not bad"}' -u potteduser -P pottedpass
 ```
 
 And execute the queryContext again, we will get the updated entity:
-```
+
+```json
 {
   "contextResponses" : [
     {

--- a/docs/stepbystep.md
+++ b/docs/stepbystep.md
@@ -4,9 +4,9 @@ Step by Step guide
 ## Index
 
 * [Introduction](#introduction)
-* [Provisioning a single device with the default API Key](#singledevice)
-* [Provisioning multiple devices with a Configuration](#withconfiguration)
-* [Using ACLs to secure provisioning access](#acls)
+* [Provisioning a single device with the default API Key](#provisioning-a-single-device-with-the-default-api-key)
+* [Provisioning multiple devices with a Configuration](#provisioning-multiple-devices-with-a-configuration)
+* [Using ACLs to secure provisioning access](#using-acls-to-secure-provisioning-access)
 
 ## Introduction
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -9,7 +9,7 @@
 * [Development documentation](#development)
 * [New transport development](#newtransport)
 
-## <a name="apioverview"/> API Overview
+## API Overview
 The JSON protocol uses plain JSON objects to send information formatted as key-value maps over any of the accepted
 transports (HTTP, MQTT or AMQP).
 
@@ -23,7 +23,7 @@ by the device to the agent. Passive or lazy attributes, i.e. those attributes wh
 request from the agent, are not implemented. Please check the issue
 [#89](https://github.com/telefonicaid/iotagent-json/issues/89) for more details and updates regarding its implementation.
 
-### <a name="httpbinding"/> HTTP binding
+###  HTTP binding
 HTTP binding is based on directly interfacing the agent from a HTTP client in the device. Json payloads are, therefore,
 directly put into Http messages.
 
@@ -31,7 +31,8 @@ directly put into Http messages.
 The payload consists of a simple plain JSON object, where each attribute of the object will be mapped to an attribute
 in the NGSI entity. The value of all the attributes will be copied as a String (as all simple attribute values in
 NGSIv1 are strings). E.g.:
-```
+
+```json
 {
   "h": "45%",
   "t": "23",
@@ -58,19 +59,19 @@ result format.
 
 * **Polling commands**:  in this case, the Agent does not send any messages to the device, being the later responsible
 of retrieving them from the IoTAgent whenever the device is ready to get commands. In order to retrieve commands from
-the IoT Agent, the device will send the query parameter 'getCmd' with value '1' as part of a normal measure. As a result 
-of this action, the IoTAgent, instead of returning an empty body (the typical response to a measurement report), will 
+the IoT Agent, the device will send the query parameter 'getCmd' with value '1' as part of a normal measure. As a result
+of this action, the IoTAgent, instead of returning an empty body (the typical response to a measurement report), will
 return a list of all the commands available for the device, in JSON format: each attribute will represent a command, and
-its value the command value. The use of a JSON return object implies that only one value can be returned for each command 
-(last value will be returned for each one). Implementation imposes another limitation in the available values for the 
-commands: a command value can't be an empty string, or a string composed exclusively by whitespaces. Whenever the device 
+its value the command value. The use of a JSON return object implies that only one value can be returned for each command
+(last value will be returned for each one). Implementation imposes another limitation in the available values for the
+commands: a command value can't be an empty string, or a string composed exclusively by whitespaces. Whenever the device
 has completed the execution of the command, it will send the response in the same way measurements are reported, but using the
 **command result format** as exposed in the [Protocol section](#protocol).
 
 Some additional remarks regarding polling commands:
 
 * Commands can be also retrieved without needed of sending a mesaure. In other words, the device is not forced to send a
-measure in order to get the accumulated commands. However, in this case note that `GET` method is used to carry the 
+measure in order to get the accumulated commands. However, in this case note that `GET` method is used to carry the
 `getCmd=1` query parameter (as they are no actual payload for measures, `POST` wouldn't make too much sense).
 
 #### Configuration retrieval
@@ -80,6 +81,7 @@ device endpoint.
 
 ##### Configuration commands
 The IoT Agent listens in this path for configuration requests coming from the device:
+
 ```
 http://<iotaURL>:<HTTP-Port>/configuration/commands
 ```
@@ -92,7 +94,7 @@ This command will trigger a query to the CB that will, as a result, end up with 
 with the `configuration/values` path (described bellow).
 
 E.g.:
-```
+```json
 {
   "type": "configuration",
   "fields": [
@@ -118,7 +120,7 @@ is sent in the same format used in multiple measure reporting: a plain JSON with
 additional parameter called `dt` is added with the system current time.
 
 E.g.:
-```
+```json
 {
   "sleepTime": "200",
   "warningLevel": "80",
@@ -195,7 +197,7 @@ This command will trigger a query to the CB that will, as a result, end up with 
 information topic (described bellow).
 
 E.g.:
-```
+```json
 {
   "type": "configuration",
   "fields": [
@@ -221,7 +223,7 @@ used in multiple measure reporting: a plain JSON with an attribute per value req
 `dt` is added with the system current time.
 
 E.g.:
-```
+```json
 {
   "sleepTime": "200",
   "warningLevel": "80",
@@ -255,7 +257,7 @@ of the command, and will be passed as it is to the corresponding `_result` attri
 For instance, if a user wants to send a command `ping` with parameters `data = 22`, he will send the following request
 to the Context Broker regarding an entity called `sen1` of type `sensor`:
 
-```
+```json
 {
   "updateAction": "UPDATE",
   "contextElements": [
@@ -280,7 +282,7 @@ to the Context Broker regarding an entity called `sen1` of type `sensor`:
 If the API key associated to de device is `ABCDEF`, and the device ID related to `sen1` entity is `id_sen1`, this
 will generate a message in the `/ABCDEF/id_sen1/cmd` topic with the following payload:
 
-```
+```json
 {"ping":{"data":"22"}}
 ```
 
@@ -295,7 +297,7 @@ At this point, Context Broker will have updated the value of `ping_status` to `P
 Once the device has executed the command, it can publish its results in the `/ABCDEF/id_sen1/cmdexe` topic with a
 payload with the following format:
 
-```
+```json
 {"ping": "1234567890"}
 ```
 
@@ -313,7 +315,7 @@ in a transformation expression in the IoTAgent). In this cases, when a reverse e
 bidirectional attribute is modified, the IoTAgent sends a command to the original device, with the name defined in the
 reverse expression attribute and the ID of the device (see Commands Syntax, just above).
 
-#### <a name="amqpbinding"/> AMQP binding
+#### AMQP binding
 
 [AMQP](https://www.amqp.org/) stands for Advance Message Queuing Protocol, and is one of the most popular protocols for message-queue systems.
 Although the protocol itself is software independent and allows for a great architectural flexibility, this transport
@@ -361,7 +363,7 @@ fields codified in hexadecimal with a fixed 4 character length, without comma se
 of this attribute, adding the "batteryType" and "percentage" fields to the entity.
 
 
-##  <a name="development"/> Development documentation
+##  Development documentation
 ### Contributions
 All contributions to this project are welcome. Developers planning to contribute should follow the [Contribution Guidelines](./docs/contribution.md)
 
@@ -451,13 +453,15 @@ grunt contributors
 ### Development environment
 
 Initialize your environment with git hooks.
+
 ```bash
 grunt init-dev-env
 ```
 
 We strongly suggest you to make an automatic execution of this task for every developer simply by adding the following
 lines to your `package.json`
-```
+
+```json
 {
   "scripts": {
      "postinstall": "grunt init-dev-env"
@@ -486,7 +490,7 @@ This command will only work after the developer has executed init-dev-env (that'
 
 This command will also launch the coverage, doc and complexity task (see in the above sections).
 
-## <a name="newtransport"/> New transport development
+## New transport development
 
 ### Overview
 This IoT Agent is prepared to serve its protocol (Plain JSON) over multiple transport protocols (MQTT, HTTP...), sharing

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -2,12 +2,13 @@
 
 ## Index
 
-* [API Overview](#apioverview)
-  * [HTTP binding](#httpbinding)
-  * [MQTT binding](#mqttbinding)
-  * [AMQP binding](#amqpbinding)
-* [Development documentation](#development)
-* [New transport development](#newtransport)
+* [API Overview](#api-overview)
+  + [HTTP binding](#http-binding)
+  + [MQTT binding](#mqtt-binding)
+  + [Value conversion](#value-conversion)
+  + [Thinking Things plugin](#thinking-things-plugin)
+* [Development documentation](#development-documentation)
+* [New transport development](#new-transport-development)
 
 ## API Overview
 The JSON protocol uses plain JSON objects to send information formatted as key-value maps over any of the accepted
@@ -128,7 +129,7 @@ E.g.:
 }
 ```
 
-###  <a name="amqpbinding"/> MQTT binding
+### MQTT binding
 MQTT binding is based on the existence of a MQTT broker and the usage of different topics to separate the different
 destinations and types of the messages (the different possible interactions are described in the following sections).
 
@@ -166,8 +167,8 @@ the following structure:
 
 Indicating in the topic the name of the attribute to be modified.
 
-In both cases, the key is the one provisioned in the IOTA through the Configuration API, and the Device ID the ID that
-was provisioned using the Provisioning API. API Key MUST be present, although can be any string in case the Device was
+In both cases, the key is the one provisioned in the IoT Agent through the Configuration API, and the Device ID the ID that
+was provisioned using the Provisioning API. API Key **must** be present, although can be any string in case the Device was
 provisioned without a link to any particular configuration.
 
 For instance, if using [Mosquitto](https://mosquitto.org/) with a device with ID `id_sen1`, API Key `ABCDEF` and attribute


### PR DESCRIPTION
After discussion with @dcalvoalonso 

With standard English usage, the “bound”  suffix in implies a direction e.g “Homeward bound" means "going **towards** my home”, therefore “Southbound” means "going **towards** the South”
In contrast, the phrase "to the North of” does not imply direction, it implies relative location — you can be to the North of a town, but travelling Southbound - i.e. towards the city.
The main common usage of Northbound/Southbound is found with motorway traffic reports e.g. “the Northbound carriageway is blocked"

Therefore the following usage is correct common English, and the existing documents should be corrected to use it: 

* Traffic **to the South of** the IoT Agent refers to the exchange of information and commands between a device and an IoT Agent (Native protocols)
Traffic **to the North of** the IoT Agent traffic considers the link between the IoT Agent  and the CB.  (NGSI)
* **Southbound** traffic refers to the commands sent from the CB down to the device
* **Northbound** traffic refers to the measurements sent up from the IoT device to the CB
* **Northbound** traffic also refers to the results of commands  sent up from the IoT device to the CB

I have updated the documents  and removed `<a>`  tags and added code highlights for ReadTheDocs whilst updating.