### PR TITLE
[WIP] upgrade mqtt dep from 1.7.0 to 1.14.1

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,3 +5,4 @@ Add: measures are sent in native JSON format when NGSIv2 is enabled (#250)
 Fix: parameter order for the MEASURE-001 error message (#290)
 Add: momment dep to packages.json
 Using precise dependencies (~=) in packages.json
+Fix: upgrade mqtt dep from 1.7.0 to 1.14.1

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "dateformat": "1.0.12",
     "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "1.0.0-alpha.7",
-    "mqtt": "1.7.0",
+    "mqtt": "1.14.1",
     "request": "2.81.0",
     "underscore": "1.8.3"
   }


### PR DESCRIPTION
1.7.0 is so older... 
2.18.3 should be our target version, but first we should check latest 1.X version (1.14.1)
This upgrade should be done in iotagent-ul also