### PR TITLE
Step: 1.7.0-next -> 1.8.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,9 +1,0 @@
-Add: unhardwire MQTT qos and retain parameters in config.js (involving new env vars IOTA_MQTT_QOS and IOTA_MQTT_RETAIN) (#279)
-Remove mongodb dependence from packages.json (already in iota-node-lib)
-Add: allow NGSIv2 for updating active attributes at CB, through configuration based on iotagent-node-lib (#250)
-Add: measures are sent in native JSON format when NGSIv2 is enabled (#250)
-Fix: parameter order for the MEASURE-001 error message (#290)
-Add: momment dep to packages.json
-Using precise dependencies (~=) in packages.json
-Fix: upgrade mqtt dep from 1.7.0 to 1.14.1
-Add: supports NGSIv2 for device provisioning (entity creation and context registration) at CB (#250)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iotagent-json",
   "description": "IoT Agent for the JSON protocol",
-  "version": "1.7.0-next",
+  "version": "1.8.0",
   "homepage": "https://github.com/telefonicaid/iotagent-json",
   "author": {
     "name": "Daniel Moran",
@@ -52,7 +52,7 @@
     "async": "1.5.2",
     "body-parser": "1.15.0",
     "dateformat": "1.0.12",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "2.7.x",
     "logops": "1.0.0-alpha.7",
     "mqtt": "1.14.1",
     "request": "2.81.0",

--- a/rpm/SPECS/iotajson.spec
+++ b/rpm/SPECS/iotajson.spec
@@ -169,6 +169,18 @@ fi
 %{_install_dir}
 
 %changelog
+* Mon Aug 06 2018 Fermin Galan <fermin.galanmarquez@telefonica.com> 1.8.0
+- Update ioagent-node-lib to 2.7.x
+- Add: allow NGSIv2 for updating active attributes at CB, through configuration based on iotagent-node-lib (#250)
+- Add: measures are sent in native JSON format when NGSIv2 is enabled (#250)
+- Add: supports NGSIv2 for device provisioning (entity creation and context registration) at CB (#250)
+- Add: unhardwire MQTT qos and retain parameters in config.js (involving new env vars IOTA_MQTT_QOS and IOTA_MQTT_RETAIN) (#279)
+- Add: momment dep to packages.json
+- Fix: parameter order for the MEASURE-001 error message (#290)
+- Fix: upgrade mqtt dep from 1.7.0 to 1.14.1
+- Using precise dependencies (~=) in packages.json
+- Remove mongodb dependence from packages.json (already in iota-node-lib)
+
 * Mon Feb 26 2018 Fermin Galan <fermin.galanmarquez@telefonica.com> 1.7.0
 - Update ioagent-node-lib to 2.6.x
 - Allow get list of commands without sending measures (empty payload) (#256)


### PR DESCRIPTION
Similar to PR #273 (except npm-shrinkwrap.json generation, which is no longer include in repository)