### PR TITLE
Remove `##Index` from ToC since it is not required

### DIFF
--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -2,7 +2,7 @@
 ==================
 ## Overview
 Being an Open Source project, everyone can contribute, provided that it respect the following points:
-* Before contributing any code, the author must make sure all the tests work (see below how to launch the tests). 
+* Before contributing any code, the author must make sure all the tests work (see below how to launch the tests).
 * Developed code must adhere to the syntax guidelines enforced by the linters.
 * Code must be developed following the branching model and changelog policies defined below.
 * For any new feature added, unit tests must be provided, following the example of the ones already created.
@@ -10,32 +10,37 @@ Being an Open Source project, everyone can contribute, provided that it respect 
 In order to start contributing:
 1. Fork this repository clicking on the "Fork" button on the upper-right area of the page.
 2. Clone your just forked repository:
-```
+
+```bash
 git clone https://github.com/your-github-username/iotagent-json.git
 ```
-3. Add the main iotagent-json repository as a remote to your forked repository (use any name for your remote 
+
+3. Add the main iotagent-json repository as a remote to your forked repository (use any name for your remote
 repository, it does not have to be iotagent-json, although we will use it in the next steps):
-```
+```bash
 git remote add iotagent-json https://github.com/telefonicaid/iotagent-json.git
 ```
 
-Before starting contributing, remember to synchronize the `master` branch in your forked repository with the `master` 
+Before starting contributing, remember to synchronize the `master` branch in your forked repository with the `master`
 branch in the main iotagent-json repository, by following this steps
 
 1. Change to your local `master` branch (in case you are not in it already):
-```
-  git checkout master
+
+```bash
+git checkout master
 ```
 2. Fetch the remote changes:
-```
-  git fetch iotagent-json
+
+```bash
+git fetch iotagent-json
 ```
 3. Merge them:
-```
-  git rebase iotagent-json/master
+
+```bash
+git rebase iotagent-json/master
 ```
 
-Contributions following this guidelines will be added to the `master` branch, and released in the next version. The 
+Contributions following this guidelines will be added to the `master` branch, and released in the next version. The
 release process is explaind in the *Releasing* section below.
 
 ## Branching model
@@ -50,7 +55,7 @@ and the tests before creating the Pull Request.
 
 Bug fixes work the same way as other tasks, with the exception of the branch name, that should be called `bug/<bugName>`.
 
-In order to contribute to the repository, these same scheme should be replicated in the forked repositories, so the 
+In order to contribute to the repository, these same scheme should be replicated in the forked repositories, so the
 new features or fixes should all come from the current version of `master` and end up in `master` again.
 
 All the `task/*` and `bug/*` branches are temporary, and should be removed once they have been merged.
@@ -61,7 +66,7 @@ point to each of the released versions of the project, they are permanent and th
 ## Changelog
 The project contains a version changelog, called CHANGES_NEXT_RELEASE, that can be found in the root of the project.
 Whenever a new feature or bug fix is going to be merged with `develop`, a new entry should be added to this changelog.
-The new entry should contain the reference number of the issue it is solving (if any). 
+The new entry should contain the reference number of the issue it is solving (if any).
 
 When a new version is released, the changelog is cleared, and remains fixed in the last commit of that version. The
 content of the changelog is also moved to the release description in the Github release.

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -1,7 +1,5 @@
 # Installation & Administration Guide
 
-## Index
-
 * [Installation](#installation)
 * [Usage](#usage)
 * [Configuration](#configuration)
@@ -11,12 +9,14 @@ There are three ways of installing the JSON IoT Agent: using Git, RPMs or Docker
 
 #### Using GIT
 In order to install the TT Agent, just clone the project and install the dependencies:
-```
+
+```bash
 git clone https://github.com/telefonicaid/iotagent-json.git
 npm install
 ```
 In order to start the IoT Agent, from the root folder of the project, type:
-```
+
+```bash
 bin/iotagent-json
 ```
 
@@ -25,27 +25,32 @@ The project contains a script for generating an RPM that can be installed in Red
 The RPM depends on Node.js 0.10 version, so EPEL repositories are advisable.
 
 In order to create the RPM, execute the following scritp, inside the `/rpm` folder:
-```
+
+```bash
 create-rpm.sh -v <versionNumber> -r <releaseNumber>
 ```
 
 Once the RPM is generated, it can be installed using the followogin command:
-```
+
+```bash
 yum localinstall --nogpg <nameOfTheRPM>.rpm
 ```
 
 The IoTA will then be installed as a linux service, and can ve started with the `service` command as usual:
-```
+
+```bash
 service iotaJSON start
 ```
 #### Using Docker
 A docker container is available on docker hub. It will start the container with the default settings defined
 in `config.js`.
-```
+
+```bash
 docker run -it --init fiware/iotagent-json
 ```
 To use your own configuration you can mount a local configuration file:
-```
+
+```bash
 docker run -it --init -v <path-to-configuration-file>:/opt/iotajson/new_config.js fiware/iotagent-json  -- new_config.js
 ```
 As an alternative, it is also possible to pass configuration using environmental variables, as explained in [Configuration with environment variables](#configuration-with-environment-variables) subsection.
@@ -53,7 +58,8 @@ As an alternative, it is also possible to pass configuration using environmental
 
 ### Usage
 In order to execute the JSON IoT Agent just execute the following command from the root folder:
-```
+
+```bash
 bin/iotagentMqtt.js
 ```
 This will start the JSON IoT Agent in the foreground. Use standard linux commands to start it in background.
@@ -136,7 +142,8 @@ The only package type allowed is RPM. In order to execute the packaging scripts,
 in the system.
 
 From the root folder of the project, create the RPM with the following commands:
-```
+
+```bash
 cd rpm
 ./create-rpm.sh -v <version-number> -r  <release-number>
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,5 +1,4 @@
 # Operations Manual: logs and alarms
-## Index
 
 * [Overview](#overview)
 * [Logs](#logs)

--- a/docs/stepbystep.md
+++ b/docs/stepbystep.md
@@ -1,8 +1,6 @@
 Step by Step guide
 ==================
 
-## Index
-
 * [Introduction](#introduction)
 * [Provisioning a single device with the default API Key](#provisioning-a-single-device-with-the-default-api-key)
 * [Provisioning multiple devices with a Configuration](#provisioning-multiple-devices-with-a-configuration)
@@ -17,6 +15,7 @@ The MQTT-JSON IoT Agent acts as a gateway for communicating devices using the MQ
 other piece which uses the NGSI protocol). The communication is based on a series of unidirectional MQTT topics
 (i.e.: each topic is used to *publish* device information or to *subscribe* to entity updates, but not both). Every
 topic has the same prefix, of the form:
+
 ```
 /<apiKey>/<deviceId>/topicSpecificPart
 ```
@@ -486,7 +485,7 @@ There are two more changes needed before we restart our test. First of all, we s
 to the IoTA Configuration, to give it full access to the MQTT Broker topics. To do so, edit the `/opt/iotajson/config.js`
  file and change the `config.mqtt` section to look like this:
 
-```
+```javascript
 config.mqtt = {
     host: 'localhost',
     port: 1883,
@@ -560,7 +559,8 @@ curl -X POST -H "Fiware-Service: myHome" -H "Fiware-ServicePath: /environment" -
 #### Sending mesaures
 
 Now we can try to provision new measures with the same command we used in the first case:
-```
+
+```bash
 mosquitto_pub -t /AAFF9977/sensor03/attrs -m '{"humidity": 76,"happiness": "Not bad"}'
 ```
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -1,7 +1,5 @@
 # User & Programmers Manual
 
-## Index
-
 * [API Overview](#api-overview)
   + [HTTP binding](#http-binding)
   + [MQTT binding](#mqtt-binding)
@@ -175,7 +173,9 @@ provisioned without a link to any particular configuration.
 For instance, if using [Mosquitto](https://mosquitto.org/) with a device with ID `id_sen1`, API Key `ABCDEF` and attribute
 IDs `h` and `t`, then humidity measures are reported this way:
 
-    $ mosquitto_pub -t /ABCDEF/id_sen1/attrs/h -m 70 -h <mosquitto_broker> -p <mosquitto_port> -u <user> -P <password>
+```bash
+$ mosquitto_pub -t /ABCDEF/id_sen1/attrs/h -m 70 -h <mosquitto_broker> -p <mosquitto_port> -u <user> -P <password>
+```
 
 #### Configuration retrieval
 The protocol offers a mechanism for the devices to retrieve its configuration (or any other value it needs from those
@@ -290,8 +290,9 @@ will generate a message in the `/ABCDEF/id_sen1/cmd` topic with the following pa
 
 If using [Mosquitto](https://mosquitto.org/), such a command is received by running the `mosquitto_sub` script:
 
-    $ mosquitto_sub -v -t /# -h <mosquitto_broker> -p <mosquitto_port> -u <user> -P <password>
-    /ABCDEF/id_sen1/cmd {"ping":{"data":"22"}}
+```bash
+$ mosquitto_sub -v -t /# -h <mosquitto_broker> -p <mosquitto_port> -u <user> -P <password> /ABCDEF/id_sen1/cmd {"ping":{"data":"22"}}
+```
 
 At this point, Context Broker will have updated the value of `ping_status` to `PENDING` for `sen1` entity. Neither
 `ping_info` nor `ping` are updated.
@@ -305,7 +306,9 @@ payload with the following format:
 
 If using [Mosquitto](https://mosquitto.org/), such command result is sent by running the `mosquitto_pub` script:
 
-    $ mosquitto_pub -t /ABCDEF/id_sen1/cmdexe -m '{"ping": "1234567890"}' -h <mosquitto_broker> -p <mosquitto_port> -u <user> -P <password>
+```bash
+$ mosquitto_pub -t /ABCDEF/id_sen1/cmdexe -m '{"ping": "1234567890"}' -h <mosquitto_broker> -p <mosquitto_port> -u <user> -P <password>
+```
 
 In the end, Context Broker will have updated the values of `ping_info` and `ping_status` to `1234567890` and `OK`,
 respectively. `ping` attribute is never updated.
@@ -431,7 +434,7 @@ npm run test:coverage
 
 ### Clean
 
-Removes `node_modules` and `coverage` folders, and  `package-lock.json` file so that a fresh copy of the project is restored. 
+Removes `node_modules` and `coverage` folders, and  `package-lock.json` file so that a fresh copy of the project is restored.
 
 ```bash
 # Use git-bash on Windows


### PR DESCRIPTION
* The ToC is suppressed with the ReadtheDocs CSS
* The ToC Header cannot be suppressed without CSS3

Therefore the title of the ToC should be removed to avoid confusion

* Add `bash` code hints where not found

Readthedocs can mis-diagnose code styles sometimes.

Related to telefonicaid/iotagent-node-lib/issues/648