### PR TITLE
Improve MQTT client configurability (adding at least support for mqtts)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 Fix: modified engine version >=6 in packages.json
 Fix: update logops dependency from 1.0.8 to 2.1.0
 Add: config.http.timeout (and associated enviroment variable IOTA_HTTP_TIMEOUT)(#152)
+Add: config.mqtt.{cert,key,protocol,rejectUnauthorized} (and associated environment variables IOTA_MQTT_*)(#372)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@ Fix: modified engine version >=6 in packages.json
 Fix: update logops dependency from 1.0.8 to 2.1.0
 Add: config.http.timeout (and associated enviroment variable IOTA_HTTP_TIMEOUT)(#152)
 Add: config.mqtt.{cert,key,protocol,rejectUnauthorized} (and associated environment variables IOTA_MQTT_*)(#372)
+Add: readding sinon as dev dependency (~6.1.0)

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -85,14 +85,24 @@ mechanism (described in the User Manual). Simultaneous use of both mechanisms is
 * **compressTimestamp**: this flags enables the timestamp compression mechanism, described in the User Manual.
 
 #### MQTT configuration
+
 These are the currently available MQTT configuration options:
+
+* **protocol**: protocol to use for connecting with the MQTT broker (`mqtt`, `mqtts`, `tcp`, `tls`, `ws`, `wss`).
 * **host**: host of the MQTT broker.
 * **port**: port where the MQTT broker is listening.
 * **defaultKey**: default API Key to use when a device is provisioned without a configuration.
+* **ca**: ca certificates to use for validating server certificates (optional). Default is to trust the well-known CAs curated by Mozilla. Mozilla's CAs are completely replaced when CAs are explicitly specified using this option.
+* **cert**: cert chains in PEM format to use for authenticating into the MQTT broker (optional). Only used when using `mqtts`, `tls` or `wss` as connnection protocol.
+* **key**: optional private keys in PEM format to use on the client side for connecting with the MQTT broker (optional). Only used when using `mqtts`, `tls` or `wss` as connection protocol.
+* **rejectUnauthorized**: whether to reject any connection which is not authorized with the list of supplied CAs. This option only has an effect when using `mqtts`, `tls` or `wss` protocols (default is `true`).
 * **username**: user name that identifies the IOTA against the MQTT broker (optional).
 * **password**: password to be used if the username is provided (optional).
 * **qos**: QoS level: at most once (0), at least once (1), exactly once (2). (default is 0).
 * **retain**: retain flag (default is false).
+
+TLS options (i.e. **ca**, **cert**, **key**, **rejectUnauthorized**) are directly linked with the ones supported by the [tls module of Node.js](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options).
+
 
 #### AMQP Binding configuration
 
@@ -120,30 +130,37 @@ transport protocol binding. The following options are accepted:
 Some of the more common variables can be configured using environment variables. The ones overriding general parameters
 in the `config.iota` set are described in the [IoTA Library Configuration manual](https://github.com/telefonicaid/iotagent-node-lib#configuration).
 
-The ones relating specific Ultralight 2.0 bindings are described in the following table.
+The ones relating specific JSON bindings are described in the following table.
 
-| Environment variable      | Configuration attribute             |
-|:------------------------- |:----------------------------------- |
-| IOTA_MQTT_HOST            | mqtt.host                           |
-| IOTA_MQTT_PORT            | mqtt.port                           |
-| IOTA_MQTT_USERNAME        | mqtt.username                       |
-| IOTA_MQTT_PASSWORD        | mqtt.password                       |
-| IOTA_MQTT_QOS             | mqtt.qos                            |
-| IOTA_MQTT_RETAIN          | mqtt.retain                         |
-| IOTA_AMQP_HOST            | amqp.host                           |
-| IOTA_AMQP_PORT            | amqp.port                           |
-| IOTA_AMQP_USERNAME        | amqp.username                       |
-| IOTA_AMQP_PASSWORD        | amqp.password                       |
-| IOTA_AMQP_EXCHANGE        | amqp.exchange                       |
-| IOTA_AMQP_QUEUE           | amqp.queue                          |
-| IOTA_AMQP_DURABLE         | amqp.durable                        |
-| IOTA_AMQP_RETRIES         | amqp.retries                        |
-| IOTA_AMQP_RETRY_TIME      | amqp.retryTime                      |
-| IOTA_HTTP_HOST            | http.host                           |
-| IOTA_HTTP_PORT            | http.port                           |
-| IOTA_HTTP_TIMEOUT         | http.timeout                        |
+| Environment variable          | Configuration attribute             |
+|:----------------------------- |:----------------------------------- |
+| IOTA_MQTT_PROTOCOL            | mqtt.protocol                       |
+| IOTA_MQTT_HOST                | mqtt.host                           |
+| IOTA_MQTT_PORT                | mqtt.port                           |
+| IOTA_MQTT_CA                  | mqtt.ca                             |
+| IOTA_MQTT_CERT                | mqtt.cert                           |
+| IOTA_MQTT_KEY                 | mqtt.key                            |
+| IOTA_MQTT_REJECT_UNAUTHORIZED | mqtt.rejectUnauthorized             |
+| IOTA_MQTT_USERNAME            | mqtt.username                       |
+| IOTA_MQTT_PASSWORD            | mqtt.password                       |
+| IOTA_MQTT_QOS                 | mqtt.qos                            |
+| IOTA_MQTT_RETAIN              | mqtt.retain                         |
+| IOTA_AMQP_HOST                | amqp.host                           |
+| IOTA_AMQP_PORT                | amqp.port                           |
+| IOTA_AMQP_USERNAME            | amqp.username                       |
+| IOTA_AMQP_PASSWORD            | amqp.password                       |
+| IOTA_AMQP_EXCHANGE            | amqp.exchange                       |
+| IOTA_AMQP_QUEUE               | amqp.queue                          |
+| IOTA_AMQP_DURABLE             | amqp.durable                        |
+| IOTA_AMQP_RETRIES             | amqp.retries                        |
+| IOTA_AMQP_RETRY_TIME          | amqp.retryTime                      |
+| IOTA_HTTP_HOST                | http.host                           |
+| IOTA_HTTP_PORT                | http.port                           |
+| IOTA_HTTP_TIMEOUT             | http.timeout                        |
 
 (HTTP-related environment variables will be used in the upcoming HTTP binding)
+
+`IOTA_MQTT_CA`, `IOTA_MQTT_CERT`, `IOTA_MQTT_KEY` environment variables should provide the file name of the file whose contents will be used for the configuration attribute.
 
 ## <a name="packaging"/> Packaging
 The only package type allowed is RPM. In order to execute the packaging scripts, the RPM Build Tools must be available

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -123,21 +123,23 @@ function unsubscribeAll(callback) {
  * Start the binding.
  */
 function start(callback) {
+    let configuration = config.getConfig().mqtt;
     var options = {
+        protocol: configuration.protocol != null ? configuration.protocol : "mqtt",
+        host: configuration.host != null ? configuration.host : "localhost",
+        port: configuration.port != null ? configuration.port : 1883,
+        key: configuration.key != null ? configuration.key : null,
+        ca: configuration.ca != null ? configuration.ca : null,
+        cert: configuration.cert != null ? configuration.cert : null,
+        rejectUnauthorized: configuration.rejectUnauthorized != null ? configuration.rejectUnauthorized : true,
+        username: configuration.username != null ? configuration.username : null,
+        password: configuration.password != null ? configuration.password : null,
         keepalive: 0,
         connectTimeout: 60 * 60 * 1000
     };
 
-    if (config.getConfig().mqtt.username && config.getConfig().mqtt.password) {
-        options.username = config.getConfig().mqtt.username;
-        options.password = config.getConfig().mqtt.password;
-    }
-
-    mqttClient = mqtt.connect(
-        'mqtt://' + config.getConfig().mqtt.host + ':' + config.getConfig().mqtt.port, options);
-
-    mqttClient.on('message', commonBindings.mqttMessageHandler);
-
+    mqttClient = mqtt.connect(options);
+    mqttClient.on('message', commonBindings.mqttmessageHandler);
     mqttClient.on('connect', function() {
         config.getLogger().info(context, 'MQTT Client connected');
         recreateSubscriptions(callback);

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -123,23 +123,24 @@ function unsubscribeAll(callback) {
  * Start the binding.
  */
 function start(callback) {
-    let configuration = config.getConfig().mqtt;
+    var mqttConfig = config.getConfig().mqtt;
+    var rejectUnauthorized = typeof mqttConfig.rejectUnauthorized === 'boolean' ? mqttConfig.rejectUnauthorized : true;
     var options = {
-        protocol: configuration.protocol != null ? configuration.protocol : "mqtt",
-        host: configuration.host != null ? configuration.host : "localhost",
-        port: configuration.port != null ? configuration.port : 1883,
-        key: configuration.key != null ? configuration.key : null,
-        ca: configuration.ca != null ? configuration.ca : null,
-        cert: configuration.cert != null ? configuration.cert : null,
-        rejectUnauthorized: configuration.rejectUnauthorized != null ? configuration.rejectUnauthorized : true,
-        username: configuration.username != null ? configuration.username : null,
-        password: configuration.password != null ? configuration.password : null,
+        protocol: mqttConfig.protocol ? mqttConfig.protocol : 'mqtt',
+        host: mqttConfig.host ? mqttConfig.host : 'localhost',
+        port: mqttConfig.port ? mqttConfig.port : 1883,
+        key: mqttConfig.key ? mqttConfig.key : null,
+        ca: mqttConfig.ca ? mqttConfig.ca : null,
+        cert: mqttConfig.cert ? mqttConfig.cert : null,
+        rejectUnauthorized: rejectUnauthorized,
+        username: mqttConfig.username ? mqttConfig.username : null,
+        password: mqttConfig.password ? mqttConfig.password : null,
         keepalive: 0,
         connectTimeout: 60 * 60 * 1000
     };
 
     mqttClient = mqtt.connect(options);
-    mqttClient.on('message', commonBindings.mqttmessageHandler);
+    mqttClient.on('message', commonBindings.mqttMessageHandler);
     mqttClient.on('connect', function() {
         config.getLogger().info(context, 'MQTT Client connected');
         recreateSubscriptions(callback);

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -24,6 +24,7 @@
 'use strict';
 
 var config = {},
+    fs = require('fs'),
     logger = require('logops');
 
 function anyIsSet(variableSet) {
@@ -38,8 +39,13 @@ function anyIsSet(variableSet) {
 
 function processEnvironmentVariables() {
     var environmentVariables = [
+            'IOTA_MQTT_PROTOCOL',
             'IOTA_MQTT_HOST',
             'IOTA_MQTT_PORT',
+            'IOTA_MQTT_CA',
+            'IOTA_MQTT_CERT',
+            'IOTA_MQTT_KEY',
+            'IOTA_MQTT_REJECT_UNAUTHORIZED',
             'IOTA_MQTT_USERNAME',
             'IOTA_MQTT_PASSWORD',
             'IOTA_MQTT_QOS',
@@ -58,8 +64,13 @@ function processEnvironmentVariables() {
             'IOTA_HTTP_TIMEOUT'
         ],
         mqttVariables = [
+            'IOTA_MQTT_PROTOCOL',
             'IOTA_MQTT_HOST',
             'IOTA_MQTT_PORT',
+            'IOTA_MQTT_CA',
+            'IOTA_MQTT_CERT',
+            'IOTA_MQTT_KEY',
+            'IOTA_MQTT_REJECT_UNAUTHORIZED',
             'IOTA_MQTT_USERNAME',
             'IOTA_MQTT_PASSWORD',
             'IOTA_MQTT_QOS',
@@ -93,12 +104,32 @@ function processEnvironmentVariables() {
         config.mqtt = {};
     }
 
+    if (process.env.IOTA_MQTT_PROTOCOL) {
+        config.mqtt.protocol = process.env.IOTA_MQTT_PROTOCOL;
+    }
+
     if (process.env.IOTA_MQTT_HOST) {
         config.mqtt.host = process.env.IOTA_MQTT_HOST;
     }
 
     if (process.env.IOTA_MQTT_PORT) {
         config.mqtt.port = process.env.IOTA_MQTT_PORT;
+    }
+
+    if (process.env.IOTA_MQTT_CA) {
+        config.mqtt.ca = fs.readFileSync(process.env.IOTA_MQTT_CA);
+    }
+
+    if (process.env.IOTA_MQTT_CERT) {
+        config.mqtt.cert = fs.readFileSync(process.env.IOTA_MQTT_CERT);
+    }
+
+    if (process.env.IOTA_MQTT_KEY) {
+        config.mqtt.key = fs.readFileSync(process.env.IOTA_MQTT_KEY);
+    }
+
+    if (process.env.IOTA_MQTT_REJECT_UNAUTHORIZED) {
+        config.mqtt.rejectUnauthorized = process.env.IOTA_MQTT_REJECT_UNAUTHORIZED.trim().toLowerCase() === 'true';
     }
 
     if (process.env.IOTA_MQTT_USERNAME) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "mocha": "5.2.0",
     "should": "13.2.3",
     "sinon": "~6.1.0",
-    "sinon-chai": "3.2.0",
     "istanbul": "~0.4.5",
     "proxyquire": "2.1.0",
     "moment": "~2.22.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "nock": "10.0.1",
     "mocha": "5.2.0",
     "should": "13.2.3",
+    "sinon": "~6.1.0",
+    "sinon-chai": "3.2.0",
     "istanbul": "~0.4.5",
     "proxyquire": "2.1.0",
     "moment": "~2.22.2",

--- a/test/unit/startup-test.js
+++ b/test/unit/startup-test.js
@@ -21,44 +21,177 @@
  * please contact with::[contacto@tid.es]
  */
 'use strict';
-var iotagentJSON = require('../../'),
+var chai = require('chai'),
+    fs = require('fs'),
+    iotagentJSON = require('../../'),
     should = require('should'),
     config = require('../../lib/configService'),
-    iotAgentConfig = require('../config-startup.js');
+    iotAgentConfig = require('../config-startup.js'),
+    mqtt = require('mqtt'),
+    sinon = require('sinon'),
+    sinonChai = require('sinon-chai');
+chai.should();
+chai.use(sinonChai);
 
 describe('Startup tests', function() {
     describe('When the IoT Agent is started with environment variables', function() {
         beforeEach(function() {
+            sinon.stub(fs, 'readFileSync');
+            sinon.stub(mqtt, 'connect').returns({
+                end: sinon.stub().callsFake(function (force, callback) {
+                    callback();
+                }),
+                on: sinon.stub().callsFake(function (type, listener) {
+                    if (type === 'connect') {
+                        listener();
+                    }
+                }),
+                subscribe: sinon.stub().callsFake(function (topics, _, callback) {
+                    callback(false);
+                }),
+                unsubscribe: sinon.spy()
+            });
+        });
+
+        afterEach(function(done) {
+            fs.readFileSync.restore();
+            mqtt.connect.restore();
+
+            delete process.env.IOTA_MQTT_PROTOCOL;
+            delete process.env.IOTA_MQTT_HOST;
+            delete process.env.IOTA_MQTT_PORT;
+            delete process.env.IOTA_MQTT_CA;
+            delete process.env.IOTA_MQTT_CERT;
+            delete process.env.IOTA_MQTT_KEY;
+            delete process.env.IOTA_MQTT_REJECT_UNAUTHORIZED;
+            delete process.env.IOTA_MQTT_USERNAME;
+            delete process.env.IOTA_MQTT_PASSWORD;
+            delete process.env.IOTA_HTTP_HOST;
+            delete process.env.IOTA_HTTP_PORT;
+            delete process.env.IOTA_HTTP_QOS;
+            delete process.env.IOTA_HTTP_RETAIN;
+
+            iotagentJSON.stop(done);
+        });
+
+        it('should load the environment variables in the internal configuration', function(done) {
             process.env.IOTA_MQTT_HOST = '127.0.0.1';
             process.env.IOTA_MQTT_PORT = '1883';
             process.env.IOTA_MQTT_USERNAME = 'usermqtt';
             process.env.IOTA_MQTT_PASSWORD = 'passmqtt';
             process.env.IOTA_HTTP_HOST = 'localhost';
             process.env.IOTA_HTTP_PORT = '2222';
-        });
 
-        afterEach(function() {
-            delete process.env.IOTA_MQTT_HOST;
-            delete process.env.IOTA_MQTT_PORT;
-            delete process.env.IOTA_MQTT_USERNAME;
-            delete process.env.IOTA_MQTT_PASSWORD;
-            delete process.env.IOTA_HTTP_HOST;
-            delete process.env.IOTA_HTTP_PORT;
-        });
-
-        afterEach(function(done) {
-            iotagentJSON.stop(done);
-        });
-
-        it('should load the environment variables in the internal configuration', function(done) {
             iotagentJSON.start(iotAgentConfig, function(error) {
                 should.not.exist(error);
-                config.getConfig().mqtt.host.should.equal('127.0.0.1');
-                config.getConfig().mqtt.port.should.equal('1883');
-                config.getConfig().mqtt.username.should.equal('usermqtt');
-                config.getConfig().mqtt.password.should.equal('passmqtt');
-                config.getConfig().http.host.should.equal('localhost');
-                config.getConfig().http.port.should.equal('2222');
+
+                mqtt.connect.should.have.been.calledOnceWithExactly({
+                    ca: null,
+                    cert: null,
+                    connectTimeout: 3600000,
+                    host: '127.0.0.1',
+                    keepalive: 0,
+                    key: null,
+                    password: 'passmqtt',
+                    port: '1883',
+                    protocol: 'mqtt',
+                    rejectUnauthorized: true,
+                    username: 'usermqtt'
+                });
+
+                var mqttConfig = config.getConfig().mqtt;
+                mqttConfig.host.should.equal('127.0.0.1');
+                mqttConfig.port.should.equal('1883');
+                mqttConfig.username.should.equal('usermqtt');
+                mqttConfig.password.should.equal('passmqtt');
+
+                var httpConfig = config.getConfig().http;
+                httpConfig.host.should.equal('localhost');
+                httpConfig.port.should.equal('2222');
+
+                done();
+            });
+        });
+
+        it('should support configuring mqtts through the use of environment variables', function(done) {
+            process.env.IOTA_MQTT_PROTOCOL = 'mqtts';
+            process.env.IOTA_MQTT_HOST = '127.0.0.1';
+            process.env.IOTA_MQTT_PORT = '8883';
+            process.env.IOTA_MQTT_REJECT_UNAUTHORIZED = 'False';
+
+            iotagentJSON.start(iotAgentConfig, function(error) {
+                should.not.exist(error);
+
+                mqtt.connect.should.have.been.calledOnceWithExactly({
+                    ca: null,
+                    cert: null,
+                    connectTimeout: 3600000,
+                    host: '127.0.0.1',
+                    keepalive: 0,
+                    key: null,
+                    password: null,
+                    port: '8883',
+                    protocol: 'mqtts',
+                    rejectUnauthorized: false,
+                    username: null
+                });
+
+                var mqttConfig = config.getConfig().mqtt;
+                mqttConfig.protocol.should.equal('mqtts');
+                mqttConfig.host.should.equal('127.0.0.1');
+                mqttConfig.port.should.equal('8883');
+                mqttConfig.rejectUnauthorized.should.equal(false);
+
+                done();
+            });
+        });
+
+        it('should support configuring tls certificates through the use of environment variables', function(done) {
+            process.env.IOTA_MQTT_PROTOCOL = 'mqtts';
+            process.env.IOTA_MQTT_HOST = '127.0.0.1';
+            process.env.IOTA_MQTT_PORT = '8883';
+            process.env.IOTA_MQTT_CERT = '/run/secrets/cert.pem';
+            process.env.IOTA_MQTT_KEY = '/run/secrets/key.pem';
+            process.env.IOTA_MQTT_CA = '/run/secrets/ca.pem';
+            process.env.IOTA_MQTT_REJECT_UNAUTHORIZED = 'true';
+
+            fs.readFileSync.callsFake(function (filename) {
+                switch(filename) {
+                    case process.env.IOTA_MQTT_CERT:
+                        return 'certcontent';
+                    case process.env.IOTA_MQTT_KEY:
+                        return 'keycontent';
+                    case process.env.IOTA_MQTT_CA:
+                        return 'cacontent';
+                }
+            });
+
+            iotagentJSON.start(iotAgentConfig, function(error) {
+                should.not.exist(error);
+
+                mqtt.connect.should.have.been.calledOnceWithExactly({
+                    ca: 'cacontent',
+                    cert: 'certcontent',
+                    connectTimeout: 3600000,
+                    host: '127.0.0.1',
+                    keepalive: 0,
+                    key: 'keycontent',
+                    password: null,
+                    port: '8883',
+                    protocol: 'mqtts',
+                    rejectUnauthorized: true,
+                    username: null
+                });
+
+                var mqttConfig = config.getConfig().mqtt;
+                mqttConfig.protocol.should.equal('mqtts');
+                mqttConfig.host.should.equal('127.0.0.1');
+                mqttConfig.port.should.equal('8883');
+                mqttConfig.cert.should.equal('certcontent');
+                mqttConfig.key.should.equal('keycontent');
+                mqttConfig.ca.should.equal('cacontent');
+                mqttConfig.rejectUnauthorized.should.equal(true);
+
                 done();
             });
         });

--- a/test/unit/startup-test.js
+++ b/test/unit/startup-test.js
@@ -21,17 +21,13 @@
  * please contact with::[contacto@tid.es]
  */
 'use strict';
-var chai = require('chai'),
-    fs = require('fs'),
+var fs = require('fs'),
     iotagentJSON = require('../../'),
     should = require('should'),
     config = require('../../lib/configService'),
     iotAgentConfig = require('../config-startup.js'),
     mqtt = require('mqtt'),
-    sinon = require('sinon'),
-    sinonChai = require('sinon-chai');
-chai.should();
-chai.use(sinonChai);
+    sinon = require('sinon');
 
 describe('Startup tests', function() {
     describe('When the IoT Agent is started with environment variables', function() {
@@ -85,7 +81,7 @@ describe('Startup tests', function() {
             iotagentJSON.start(iotAgentConfig, function(error) {
                 should.not.exist(error);
 
-                mqtt.connect.should.have.been.calledOnceWithExactly({
+                mqtt.connect.calledOnceWithExactly({
                     ca: null,
                     cert: null,
                     connectTimeout: 3600000,
@@ -97,7 +93,7 @@ describe('Startup tests', function() {
                     protocol: 'mqtt',
                     rejectUnauthorized: true,
                     username: 'usermqtt'
-                });
+                }).should.equal(true);
 
                 var mqttConfig = config.getConfig().mqtt;
                 mqttConfig.host.should.equal('127.0.0.1');
@@ -122,7 +118,7 @@ describe('Startup tests', function() {
             iotagentJSON.start(iotAgentConfig, function(error) {
                 should.not.exist(error);
 
-                mqtt.connect.should.have.been.calledOnceWithExactly({
+                mqtt.connect.calledOnceWithExactly({
                     ca: null,
                     cert: null,
                     connectTimeout: 3600000,
@@ -134,7 +130,7 @@ describe('Startup tests', function() {
                     protocol: 'mqtts',
                     rejectUnauthorized: false,
                     username: null
-                });
+                }).should.equal(true);
 
                 var mqttConfig = config.getConfig().mqtt;
                 mqttConfig.protocol.should.equal('mqtts');
@@ -169,7 +165,7 @@ describe('Startup tests', function() {
             iotagentJSON.start(iotAgentConfig, function(error) {
                 should.not.exist(error);
 
-                mqtt.connect.should.have.been.calledOnceWithExactly({
+                mqtt.connect.calledOnceWithExactly({
                     ca: 'cacontent',
                     cert: 'certcontent',
                     connectTimeout: 3600000,
@@ -181,7 +177,7 @@ describe('Startup tests', function() {
                     protocol: 'mqtts',
                     rejectUnauthorized: true,
                     username: null
-                });
+                }).should.equal(true);
 
                 var mqttConfig = config.getConfig().mqtt;
                 mqttConfig.protocol.should.equal('mqtts');


### PR DESCRIPTION
This PR pretends to add support for using the mqtts transport. This PR also provides support for using client authentication using certificates and allows to configure whether or not allowing invalid (e.g. expired, self-signed, ...) certificates through the `rejectUnauthorized` option.

I have being using these changes with success, but it is true that this PR is currently not providing any unit tests, documentation... and probably it is not using the proper code style. Please, let me know whatever change is required to make this acceptable for inclusion 😃.