### PR TITLE
Implements NGSIv2 context forwarding (from PR #392 with additions)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,4 @@
 ADD PM2_ENABLED flag to Docker
 Upgrade NodeJS version from 8.16.0 to 8.16.1 in Dockerfile due to security issues
+
+NOTE: in the "upgrade iotagent-node-lib from X to Y" include a mention about NGSIv2 forwarding support and issue #250

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "git://github.com/dcalvoalonso/iotagent-node-lib.git#task/lazyAttsNgsiv2",
     "logops": "2.1.0",
     "mqtt": "2.18.8",
     "request": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "git://github.com/dcalvoalonso/iotagent-node-lib.git#task/lazyAttsNgsiv2",
+    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#task/lazyAttsNgsiv2-pr762",
     "logops": "2.1.0",
     "mqtt": "2.18.8",
     "request": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#task/lazyAttsNgsiv2-pr762",
+    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "2.1.0",
     "mqtt": "2.18.8",
     "request": "2.88.0",

--- a/test/unit/ngsiv2/HTTP_commands_test.js
+++ b/test/unit/ngsiv2/HTTP_commands_test.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-json
+ *
+ * iotagent-json is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-json is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-json.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+'use strict';
+
+var iotagentMqtt = require('../../../'),
+    config = require('./config-test.js'),
+    nock = require('nock'),
+    should = require('should'),
+    iotAgentLib = require('iotagent-node-lib'),
+    async = require('async'),
+    request = require('request'),
+    utils = require('../../utils'),
+    mockedClientServer,
+    contextBrokerMock;
+
+describe('HTTP: Commands', function() {
+    beforeEach(function(done) {
+        var provisionOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/deviceProvisioning/provisionCommandHTTP.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        config.logLevel = 'INFO';
+
+        nock.cleanAll();
+
+        contextBrokerMock = nock('http://192.168.1.1:1026')
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/registrations')
+            .reply(201, null, { Location: '/v2/registrations/6319a7f5254b05844116584d' });
+
+        contextBrokerMock
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/entities?options=upsert')
+            .reply(204);
+
+        iotagentMqtt.start(config, function() {
+            request(provisionOptions, function(error, response, body) {
+                done();
+            });
+        });
+    });
+
+    afterEach(function(done) {
+        nock.cleanAll();
+        async.series([iotAgentLib.clearAll, iotagentMqtt.stop], done);
+    });
+
+    describe('When a command arrive to the Agent for a device with the HTTP protocol', function() {
+        var commandOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand1.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus1.json')
+                )
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus6.json')
+                )
+                .reply(204);
+
+            mockedClientServer = nock('http://localhost:9876')
+                .post('/command', function(body) {
+                    return body.PING || body.PING.data || body.PING.data === 22;
+                })
+                .reply(200, '{"PING":{"data":"22"}}');
+        });
+
+        it('should return a 204 OK without errors', function(done) {
+            request(commandOptions, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+                done();
+            });
+        });
+        it('should update the status in the Context Broker', function(done) {
+            request(commandOptions, function(error, response, body) {
+                contextBrokerMock.done();
+                done();
+            });
+        });
+        it('should publish the command information in the MQTT topic', function(done) {
+            request(commandOptions, function(error, response, body) {
+                setTimeout(function() {
+                    mockedClientServer.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+});

--- a/test/unit/ngsiv2/MQTT_commands_test.js
+++ b/test/unit/ngsiv2/MQTT_commands_test.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-json
+ *
+ * iotagent-json is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-json is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-json.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+'use strict';
+
+var iotagentMqtt = require('../../../'),
+    mqtt = require('mqtt'),
+    config = require('./config-test.js'),
+    nock = require('nock'),
+    should = require('should'),
+    iotAgentLib = require('iotagent-node-lib'),
+    async = require('async'),
+    request = require('request'),
+    utils = require('../../utils'),
+    contextBrokerMock,
+    mqttClient;
+
+describe('MQTT: Commands', function() {
+    beforeEach(function(done) {
+        var provisionOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/deviceProvisioning/provisionCommand1.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        config.logLevel = 'INFO';
+
+        nock.cleanAll();
+
+        mqttClient = mqtt.connect(
+            'mqtt://' + config.mqtt.host,
+            {
+                keepalive: 0,
+                connectTimeout: 60 * 60 * 1000
+            }
+        );
+
+        mqttClient.subscribe('/1234/MQTT_2/cmd', null);
+
+        contextBrokerMock = nock('http://192.168.1.1:1026')
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/registrations')
+            .reply(201, null, { Location: '/v2/registrations/6319a7f5254b05844116584d' });
+
+        contextBrokerMock
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/entities?options=upsert')
+            .reply(204);
+
+        iotagentMqtt.start(config, function() {
+            request(provisionOptions, function(error, response, body) {
+                done();
+            });
+        });
+    });
+
+    afterEach(function(done) {
+        nock.cleanAll();
+        mqttClient.unsubscribe('/1234/MQTT_2/cmd', null);
+        mqttClient.end();
+
+        async.series([iotAgentLib.clearAll, iotagentMqtt.stop], done);
+    });
+
+    describe('When a command arrive to the Agent for a device with the MQTT_UL protocol', function() {
+        var commandOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand1.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus1.json')
+                )
+                .reply(204);
+        });
+
+        it('should return a 204 OK without errors', function(done) {
+            request(commandOptions, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+                done();
+            });
+        });
+        it('should update the status in the Context Broker', function(done) {
+            request(commandOptions, function(error, response, body) {
+                contextBrokerMock.done();
+                done();
+            });
+        });
+        it('should publish the command information in the MQTT topic', function(done) {
+            var commandMsg = '{"PING":{"data":"22"}}',
+                payload;
+
+            mqttClient.on('message', function(topic, data) {
+                payload = data.toString();
+            });
+
+            request(commandOptions, function(error, response, body) {
+                setTimeout(function() {
+                    should.exist(payload);
+                    payload.should.equal(commandMsg);
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a command update arrives to the MQTT command topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/op/update', utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json'))
+                .reply(204);
+        });
+
+        it('should send an update request to the Context Broker', function(done) {
+            mqttClient.publish('/1234/MQTT_2/cmdexe', '{ "PING": "1234567890" }', null, function(error) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 200);
+            });
+        });
+    });
+});

--- a/test/unit/ngsiv2/commandsAmqp-test.js
+++ b/test/unit/ngsiv2/commandsAmqp-test.js
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-ul
+ *
+ * iotagent-ul is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-ul is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-ul.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[iot_support@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+
+'use strict';
+
+var iotagentMqtt = require('../../../'),
+    config = require('./config-test.js'),
+    nock = require('nock'),
+    async = require('async'),
+    request = require('request'),
+    utils = require('../../utils'),
+    should = require('should'),
+    iotAgentLib = require('iotagent-node-lib'),
+    amqp = require('amqplib/callback_api'),
+    apply = async.apply,
+    contextBrokerMock,
+    oldTransport,
+    amqpConn,
+    channel;
+
+function startConnection(exchange, callback) {
+    amqp.connect(
+        'amqp://localhost',
+        function(err, conn) {
+            amqpConn = conn;
+
+            conn.createChannel(function(err, ch) {
+                ch.assertExchange(exchange, 'topic', {});
+
+                channel = ch;
+                callback(err);
+            });
+        }
+    );
+}
+
+describe('AMQP Transport binding: commands', function() {
+    beforeEach(function(done) {
+        var provisionOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/deviceProvisioning/provisionCommand5.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        config.logLevel = 'INFO';
+
+        nock.cleanAll();
+
+        contextBrokerMock = nock('http://192.168.1.1:1026')
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/registrations')
+            .reply(201, null, { Location: '/v2/registrations/6319a7f5254b05844116584d' });
+
+        contextBrokerMock
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/entities?options=upsert')
+            .reply(204);
+
+        oldTransport = config.defaultTransport;
+        config.defaultTransport = 'AMQP';
+
+        async.series(
+            [
+                apply(iotagentMqtt.start, config),
+                apply(request, provisionOptions),
+                apply(startConnection, config.amqp.exchange)
+            ],
+            done
+        );
+    });
+
+    afterEach(function(done) {
+        nock.cleanAll();
+
+        amqpConn.close();
+
+        config.defaultTransport = oldTransport;
+
+        async.series([iotAgentLib.clearAll, iotagentMqtt.stop], done);
+    });
+
+    describe('When a command arrive to the Agent for a device with the AMQP protocol', function() {
+        var commandOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand1.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': 'gardens'
+            }
+        };
+
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus1.json')
+                )
+                .reply(204);
+        });
+
+        it('should return a 204 OK without errors', function(done) {
+            request(commandOptions, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+                done();
+            });
+        });
+        it('should update the status in the Context Broker', function(done) {
+            request(commandOptions, function(error, response, body) {
+                contextBrokerMock.done();
+                done();
+            });
+        });
+        it('should publish the command information in the AMQP topic', function(done) {
+            var commandMsg = '{"PING":{"data":"22"}}',
+                payload;
+
+            channel.assertExchange(config.amqp.exchange, 'topic', config.amqp.options);
+
+            channel.assertQueue('client-queue', { exclusive: false }, function(err, q) {
+                channel.bindQueue(q.queue, config.amqp.exchange, '.' + config.defaultKey + '.MQTT_2.cmd');
+
+                channel.consume(
+                    q.queue,
+                    function(msg) {
+                        payload = msg.content.toString();
+                    },
+                    { noAck: true }
+                );
+
+                request(commandOptions, function(error, response, body) {
+                    setTimeout(function() {
+                        should.exist(payload);
+                        payload.should.equal(commandMsg);
+                        done();
+                    }, 1000);
+                });
+            });
+        });
+    });
+
+    describe('When a command update arrives to the AMQP command topic', function() {
+        beforeEach(function() {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/op/update', utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json'))
+                .reply(204);
+        });
+
+        it('should send an update request to the Context Broker', function(done) {
+            channel.assertExchange(config.amqp.exchange, 'topic', config.amqp.options);
+            channel.publish(config.amqp.exchange, '.1234.MQTT_2.cmdexe', new Buffer('{"PING":"1234567890"}'));
+
+            setTimeout(function() {
+                contextBrokerMock.done();
+                done();
+            }, 1000);
+        });
+    });
+
+    describe('When a command update arrives with a single text value', function() {
+        var provisionOptionsAlt = {
+                url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+                method: 'POST',
+                json: utils.readExampleFile('./test/deviceProvisioning/provisionCommand6.json'),
+                headers: {
+                    'fiware-service': 'smartGondor',
+                    'fiware-servicepath': '/gardens'
+                }
+            },
+            configurationOptions = {
+                url: 'http://localhost:' + config.iota.server.port + '/iot/services',
+                method: 'POST',
+                json: utils.readExampleFile('./test/deviceProvisioning/provisionGroup1.json'),
+                headers: {
+                    'fiware-service': 'smartGondor',
+                    'fiware-servicepath': '/gardens'
+                }
+            },
+            commandOptions = {
+                url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
+                method: 'POST',
+                json: utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand3.json'),
+                headers: {
+                    'fiware-service': 'smartGondor',
+                    'fiware-servicepath': 'gardens'
+                }
+            };
+
+        beforeEach(function(done) {
+            nock.cleanAll();
+
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/registrations')
+                .reply(201, null, { Location: '/v2/registrations/6319a7f5254b05844116584d' });
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post('/v2/entities?options=upsert')
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Fourth%20MQTT%20Device/attrs?type=MQTTCommandDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus3.json')
+                )
+                .reply(204);
+
+            request(configurationOptions, function(error, response, body) {
+                request(provisionOptionsAlt, function(error, response, body) {
+                    done();
+                });
+            });
+        });
+
+        it('should publish the command information in the AMQP topic', function(done) {
+            var commandMsg = '{"PING":22}',
+                payload;
+
+            channel.assertExchange(config.amqp.exchange, 'topic', config.amqp.options);
+
+            channel.assertQueue('client-queue', { exclusive: false }, function(err, q) {
+                channel.bindQueue(q.queue, config.amqp.exchange, '.ALTERNATIVE.MQTT_4.cmd');
+
+                channel.consume(
+                    q.queue,
+                    function(msg) {
+                        payload = msg.content.toString();
+                    },
+                    { noAck: true }
+                );
+
+                request(commandOptions, function(error, response, body) {
+                    setTimeout(function() {
+                        should.exist(payload);
+                        payload.should.equal(commandMsg);
+                        done();
+                    }, 1000);
+                });
+            });
+        });
+    });
+});

--- a/test/unit/ngsiv2/commandsPolling-test.js
+++ b/test/unit/ngsiv2/commandsPolling-test.js
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-ul
+ *
+ * iotagent-ul is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-ul is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-ul.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[iot_support@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+
+'use strict';
+
+var iotagentUl = require('../../../'),
+    config = require('./config-test.js'),
+    nock = require('nock'),
+    iotAgentLib = require('iotagent-node-lib'),
+    should = require('should'),
+    request = require('request'),
+    utils = require('../../utils'),
+    mockedClientServer,
+    contextBrokerMock;
+
+describe('HTTP Transport binding: polling commands', function() {
+    var commandOptions = {
+        url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
+        method: 'POST',
+        json: utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand1.json'),
+        headers: {
+            'fiware-service': 'smartGondor',
+            'fiware-servicepath': '/gardens'
+        }
+    };
+
+    beforeEach(function(done) {
+        var provisionOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/deviceProvisioning/provisionCommand4.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        nock.cleanAll();
+
+        contextBrokerMock = nock('http://192.168.1.1:1026')
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/registrations')
+            .reply(201, null, { Location: '/v2/registrations/6319a7f5254b05844116584d' });
+
+        contextBrokerMock
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/entities?options=upsert')
+            .reply(204);
+
+        mockedClientServer = nock('http://localhost:9876')
+            .post('/command', 'MQTT_2@PING|data=22')
+            .reply(200, 'MQTT_2@PING|1234567890');
+
+        contextBrokerMock
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', '/gardens')
+            .post('/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice')
+            .reply(204);
+
+        iotagentUl.start(config, function(error) {
+            request(provisionOptions, function(error, response, body) {
+                done();
+            });
+        });
+    });
+
+    afterEach(function(done) {
+        nock.cleanAll();
+
+        iotAgentLib.clearAll(function() {
+            iotagentUl.stop(done);
+        });
+    });
+
+    describe('When a command arrives to the IoTA with HTTP transport and no endpoint', function() {
+        it('should return a 204 OK without errors', function(done) {
+            request(commandOptions, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+                done();
+            });
+        });
+
+        it('should be stored in the commands collection', function(done) {
+            request(commandOptions, function(error, response, body) {
+                iotAgentLib.commandQueue('smartGondor', '/gardens', 'MQTT_2', function(error, list) {
+                    should.not.exist(error);
+                    list.count.should.equal(1);
+                    list.commands[0].name.should.equal('PING');
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('When a device asks for the pending commands', function() {
+        var deviceRequest = {
+            url: 'http://localhost:' + config.http.port + '/iot/json',
+            method: 'POST',
+            json: {
+                a: 23
+            },
+            qs: {
+                i: 'MQTT_2',
+                k: '1234',
+                getCmd: 1
+            }
+        };
+
+        beforeEach(function(done) {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/pollingMeasure.json')
+                )
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus4.json')
+                )
+                .reply(204);
+
+            request(commandOptions, done);
+        });
+
+        it('should return a list of the pending commands', function(done) {
+            request(deviceRequest, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(200);
+                should.exist(body.PING);
+                should.exist(body.PING.data);
+                body.PING.data.should.equal('22');
+                done();
+            });
+        });
+
+        it('should be marked as delivered in the Context Broker', function(done) {
+            request(deviceRequest, function(error, response, body) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 50);
+            });
+        });
+
+        it('should remove them from the IoTAgent', function(done) {
+            request(deviceRequest, function(error, response, body) {
+                iotAgentLib.commandQueue('smartGondor', '/gardens', 'MQTT_2', function(error, list) {
+                    should.not.exist(error);
+                    list.count.should.equal(0);
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('When a device asks for the pending commands without body', function() {
+        var deviceRequest = {
+            url: 'http://localhost:' + config.http.port + '/iot/json',
+            method: 'POST',
+            json: {
+                a: 23
+            },
+            qs: {
+                i: 'MQTT_2',
+                k: '1234',
+                getCmd: 1
+            }
+        };
+
+        var deviceRequestWithoutPayload = {
+            url: 'http://localhost:' + config.http.port + '/iot/json',
+            method: 'GET',
+            json: true,
+            qs: {
+                i: 'MQTT_2',
+                k: '1234',
+                getCmd: 1
+            }
+        };
+
+        beforeEach(function(done) {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/pollingMeasure.json')
+                )
+                .reply(204);
+
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus4.json')
+                )
+                .reply(204);
+
+            request(commandOptions, done);
+        });
+
+        it('should return a list of the pending commands', function(done) {
+            request(deviceRequestWithoutPayload, function(error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(200);
+                should.exist(body.PING);
+                should.exist(body.PING.data);
+                body.PING.data.should.equal('22');
+                done();
+            });
+        });
+
+        it('should be marked as delivered in the Context Broker', function(done) {
+            request(deviceRequest, function(error, response, body) {
+                setTimeout(function() {
+                    contextBrokerMock.done();
+                    done();
+                }, 50);
+            });
+        });
+
+        it('should remove them from the IoTAgent', function(done) {
+            request(deviceRequest, function(error, response, body) {
+                iotAgentLib.commandQueue('smartGondor', '/gardens', 'MQTT_2', function(error, list) {
+                    should.not.exist(error);
+                    list.count.should.equal(0);
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('When a device asks for the list of commands and there is more than one command', function() {
+        it('should retrieve the list sepparated by the "#" character');
+    });
+
+    describe('When a device sends the result for a pending command', function() {
+        var commandResponse = {
+            uri: 'http://localhost:' + config.http.port + '/iot/json/commands',
+            method: 'POST',
+            json: {
+                PING: 'MADE_OK'
+            },
+            qs: {
+                i: 'MQTT_2',
+                k: '1234'
+            }
+        };
+
+        beforeEach(function(done) {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus5.json')
+                )
+                .reply(204);
+
+            request(commandOptions, done);
+        });
+
+        it('should update the entity in the Context Broker with the OK status and the result', function(done) {
+            request(commandResponse, function(error, response, body) {
+                contextBrokerMock.done();
+                done();
+            });
+        });
+    });
+
+    describe('When the device sends the result for multiple pending commands', function() {
+        it('should make all the updates in the Context Broker');
+    });
+
+    describe('When a device sends measures and command responses mixed in a message', function() {
+        it('should send both the command updates and the measures to the Context Broker');
+    });
+});

--- a/test/unit/ngsiv2/contextRequests/pollingMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/pollingMeasure.json
@@ -1,0 +1,6 @@
+{
+  "a": {
+    "type": "string",
+    "value": 23
+  }
+}

--- a/test/unit/ngsiv2/contextRequests/updateCommand1.json
+++ b/test/unit/ngsiv2/contextRequests/updateCommand1.json
@@ -1,0 +1,15 @@
+{
+  "actionType": "update",
+  "entities": [
+    {
+      "id": "Second MQTT Device",
+      "type": "AnMQTTDevice",
+      "PING": {
+        "type": "command",
+        "value":{
+          "data": "22"
+        }
+      }
+    }
+  ]
+}

--- a/test/unit/ngsiv2/contextRequests/updateCommand3.json
+++ b/test/unit/ngsiv2/contextRequests/updateCommand3.json
@@ -1,0 +1,13 @@
+{
+  "actionType": "update",
+  "entities": [
+    {
+      "id": "Fourth MQTT Device",
+      "type": "MQTTCommandDevice",
+      "PING": {
+          "type": "command",
+          "value": 22
+      }
+    }
+  ]
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatus1.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus1.json
@@ -1,0 +1,6 @@
+{
+  "PING_status": {
+    "type": "commandStatus",
+    "value": "PENDING"
+  }
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatus2.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus2.json
@@ -1,0 +1,15 @@
+{
+	"actionType": "append",
+	"entities": [{
+		"id": "Second MQTT Device",
+		"type": "AnMQTTDevice",
+		"PING_status": {
+			"type": "commandStatus",
+			"value": "OK"
+		},
+		"PING_info": {
+			"type": "commandResult",
+			"value": "1234567890"
+		}
+	}]
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatus3.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus3.json
@@ -1,0 +1,6 @@
+{
+  "PING_status": {
+    "type": "commandStatus",
+    "value": "PENDING"
+  }
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatus4.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus4.json
@@ -1,0 +1,10 @@
+{
+  "PING_status": {
+    "type": "commandStatus",
+    "value": "DELIVERED"
+  },
+  "PING_info": {
+    "type": "commandResult",
+    "value": " "
+  }
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatus5.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus5.json
@@ -1,0 +1,10 @@
+{
+  "PING_status": {
+    "type": "commandStatus",
+    "value": "OK"
+  },
+  "PING_info": {
+    "type": "commandResult",
+    "value": "MADE_OK"
+  }
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatus6.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus6.json
@@ -1,0 +1,12 @@
+{
+  "PING_status": {
+    "type": "commandStatus",
+    "value": "OK"
+  },
+  "PING_info": {
+    "type": "commandResult",
+    "value": {
+      "data": "22"
+    }
+  }
+}


### PR DESCRIPTION
This PR migrates the work done by PR #392 by @dcalvoalonso. In particular, it can be checked that:

* First commit 18adce6 has +984 -1 modifications and corresponds to PR #392 with +984 -1 (exact match)
* Second commit d97b7e1 is for setting the iotagent-node-lib branch to the one used in https://github.com/telefonicaid/iotagent-node-lib/pull/813

Commits beyond the second one are additional fixes.