### PR TITLE
log error -> log warn when device of apikey is not found

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: move to warn error log about device not found
 - Add: multimeasure support for HTTP transport (#391, partially)
 - Add: check response obj before use it handling http commands
 - Upgrade NodeJS version from 8.16.1 to 10.17.0 in Dockerfile due to Node 8 End-of-Life 

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -258,7 +258,7 @@ function messageHandler(topic, message, protocol) {
 
     function processDeviceMeasure(error, device) {
         if (error) {
-            config.getLogger().error(context, 'MEASURES-004: Device not found for topic [%s]', topic);
+            config.getLogger().warn(context, 'MEASURES-004: Device not found for topic [%s]', topic);
         } else {
             if (topicInformation[3] === 'configuration' && topicInformation[4] === 'commands' && parsedMessage) {
                 manageConfigurationRequest(apiKey, deviceId, device, parsedMessage);


### PR DESCRIPTION
IMHO is not an error, its a client mitake.
twin PR https://github.com/telefonicaid/iotagent-ul/pull/416