### PR TITLE
Replace checkNgsi2 with isCurrentNgsi

### DIFF
--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -85,7 +85,7 @@ function guessType(attribute, device) {
     }
 
     if (attribute === constants.TIMESTAMP_ATTRIBUTE) {
-        if (iotAgentLib.configModule.checkNgsi2()) {
+        if (iotAgentLib.configModule.isCurrentNgsi()) {
             return constants.TIMESTAMP_TYPE_NGSI2;
         }
         return constants.TIMESTAMP_TYPE;

--- a/lib/iotaUtils.js
+++ b/lib/iotaUtils.js
@@ -82,7 +82,7 @@ function manageConfiguration(apiKey, deviceId, device, objMessage, sendFunction,
     }
 
     function extractAttributes(results, callback) {
-        if (iotAgentLib.configModule.checkNgsi2()) {
+        if (iotAgentLib.configModule.isCurrentNgsi()) {
             callback(null, results);
         } else if (
             results.contextResponses &&
@@ -138,7 +138,7 @@ function createConfigurationNotification(results) {
     const configurations = {};
     const now = new Date();
 
-    if (iotAgentLib.configModule.checkNgsi2()) {
+    if (iotAgentLib.configModule.isCurrentNgsi()) {
         for (var att in results) {
             configurations[att] = results[att].value;
         }

--- a/lib/thinkingThingPlugin.js
+++ b/lib/thinkingThingPlugin.js
@@ -276,7 +276,7 @@ function updatePluginNgsi1(entity, entityType, callback) {
  * @param {Object} entity           NGSI Entity as it would have been sent before the plugin.
  */
 function updatePlugin(entity, entityType, callback) {
-    if (iotAgentLib.configModule.checkNgsi2()) {
+    if (iotAgentLib.configModule.isCurrentNgsi()) {
         updatePluginNgsi2(entity, entityType, callback);
     } else {
         updatePluginNgsi1(entity, entityType, callback);


### PR DESCRIPTION
Related https://github.com/telefonicaid/iotagent-node-lib/issues/963

Note: the `isCurrentNgsi()` can be removed once NGSI-v1 is dropped.