### PR TITLE
set 60 default keepalive mqtt value

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+Fix: Set 60 seconds for default mqtt keepalive option (#413)
 Add: Support of multimeasure for MQTT and AMQP transport (#462)

--- a/config.js
+++ b/config.js
@@ -97,9 +97,9 @@ config.mqtt = {
      */
     retryTime: 5,
     /**
-     * Time to keep connection open between client and MQTT broker (default is 0 seconds)
+     * Time to keep connection open between client and MQTT broker (default is 60 seconds)
      */
-    keepalive: 0,
+    keepalive: 60,
 
     /**
      * Whether to use slashes at the beginning of topic when sending or not

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -129,7 +129,7 @@ These are the currently available MQTT configuration options:
 -   **retain**: retain flag (default is false).
 -   **retries**: Number of MQTT connection error retries (default is 5).
 -   **retryTime**: Time between MQTT connection retries (default is 5 seconds).
--   **keepalive**: Time to keep connection open between client and MQTT broker (default is 0 seconds). If you experience
+-   **keepalive**: Time to keep connection open between client and MQTT broker (default is 60 seconds). If you experience
     disconnnection problems using 0 (as the one described in
     [this case](https://github.com/telefonicaid/iotagent-json/issues/455)) a value greater than 0 is recommended.
 -   **avoidLeadingSlash** this flag sets whether the agent publishes commands to topics starting with slash (default in


### PR DESCRIPTION
fix https://github.com/telefonicaid/iotagent-json/issues/413

60 is default value for keepalive in python and nodejs mqtt libraries:

https://www.npmjs.com/package/mqtt#mqttclientstreambuilder-options