### PR TITLE
DeprecationWarning: Buffer() is deprecated due to security and usability issues.

### DIFF
--- a/lib/bindings/AMQPBinding.js
+++ b/lib/bindings/AMQPBinding.js
@@ -57,7 +57,7 @@ function executeCommand(apiKey, device, serializedPayload, callback) {
     amqpChannel.publish(
         config.getConfig().amqp.exchange,
         '.' + apiKey + '.' + device.id + '.cmd',
-        new Buffer(serializedPayload)
+       Buffer.from(serializedPayload)
     );
     callback();
 }

--- a/test/unit/amqpBinding-test.js
+++ b/test/unit/amqpBinding-test.js
@@ -106,7 +106,7 @@ describe('AMQP Transport binding: measures', function() {
         });
 
         it('should send a new update context request to the Context Broker with just that attribute', function(done) {
-            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs.a', new Buffer('23'));
+            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs.a', Buffer.from('23'));
 
             setTimeout(function() {
                 contextBrokerMock.done();
@@ -145,7 +145,7 @@ describe('AMQP Transport binding: measures', function() {
         });
 
         it('should send a new update context request to the Context Broker with just that attribute', function(done) {
-            channel.publish(config.amqp.exchange, '.80K09H324HV8732.MQTT_UNPROVISIONED.attrs.a', new Buffer('23'));
+            channel.publish(config.amqp.exchange, '.80K09H324HV8732.MQTT_UNPROVISIONED.attrs.a', Buffer.from('23'));
 
             setTimeout(function() {
                 contextBrokerUnprovMock.done();
@@ -164,7 +164,7 @@ describe('AMQP Transport binding: measures', function() {
         });
 
         it('should send a single update context request with all the attributes', function(done) {
-            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs', new Buffer(JSON.stringify({ a: '23' })));
+            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs', Buffer.from(JSON.stringify({ a: '23' })));
 
             setTimeout(function() {
                 contextBrokerMock.done();
@@ -183,7 +183,7 @@ describe('AMQP Transport binding: measures', function() {
         });
 
         it('should silently ignore the error (without crashing)', function(done) {
-            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs', new Buffer('notAULPayload '));
+            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs', Buffer.from('notAULPayload '));
 
             setTimeout(function() {
                 done();
@@ -204,7 +204,7 @@ describe('AMQP Transport binding: measures', function() {
             channel.publish(
                 config.amqp.exchange,
                 '.1234.MQTT_2.attrs',
-                new Buffer(
+                Buffer.from(
                     JSON.stringify({
                         a: '23',
                         b: '98'

--- a/test/unit/amqpBinding-test2.js
+++ b/test/unit/amqpBinding-test2.js
@@ -112,7 +112,7 @@ describe('AMQP Transport binding: multiple measures', function () {
             channel.publish(
                 config.amqp.exchange,
                 '.1234.MQTT_2.attrs',
-                new Buffer(JSON.stringify([{ a: '23' }, { a: '25' }]))
+                Buffer.from(JSON.stringify([{ a: '23' }, { a: '25' }]))
             );
 
             setTimeout(function () {
@@ -141,7 +141,7 @@ describe('AMQP Transport binding: multiple measures', function () {
             channel.publish(
                 config.amqp.exchange,
                 '.1234.MQTT_2.attrs',
-                new Buffer(
+                Buffer.from(
                     JSON.stringify([
                         {
                             a: '23',

--- a/test/unit/commandsAmqp-test.js
+++ b/test/unit/commandsAmqp-test.js
@@ -182,7 +182,7 @@ describe('AMQP Transport binding: commands', function() {
 
         it('should send an update request to the Context Broker', function(done) {
             channel.assertExchange(config.amqp.exchange, 'topic', config.amqp.options);
-            channel.publish(config.amqp.exchange, '.1234.MQTT_2.cmdexe', new Buffer('{"PING":"1234567890"}'));
+            channel.publish(config.amqp.exchange, '.1234.MQTT_2.cmdexe', Buffer.from('{"PING":"1234567890"}'));
 
             setTimeout(function() {
                 contextBrokerMock.done();

--- a/test/unit/ngsiv2/amqpBinding-test.js
+++ b/test/unit/ngsiv2/amqpBinding-test.js
@@ -115,7 +115,7 @@ describe('AMQP Transport binding: measures', function() {
         });
 
         it('should send a new update context request to the Context Broker with just that attribute', function(done) {
-            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs.a', new Buffer('23'));
+            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs.a', Buffer.from('23'));
 
             setTimeout(function() {
                 contextBrokerMock.done();
@@ -161,7 +161,7 @@ describe('AMQP Transport binding: measures', function() {
         });
 
         it('should send a new update context request to the Context Broker with just that attribute', function(done) {
-            channel.publish(config.amqp.exchange, '.80K09H324HV8732.JSON_UNPROVISIONED.attrs.a', new Buffer('23'));
+            channel.publish(config.amqp.exchange, '.80K09H324HV8732.JSON_UNPROVISIONED.attrs.a', Buffer.from('23'));
 
             setTimeout(function() {
                 contextBrokerUnprovMock.done();
@@ -184,7 +184,7 @@ describe('AMQP Transport binding: measures', function() {
         });
 
         it('should send a single update context request with all the attributes', function(done) {
-            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs', new Buffer(JSON.stringify({ a: '23' })));
+            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs', Buffer.from(JSON.stringify({ a: '23' })));
 
             setTimeout(function() {
                 contextBrokerMock.done();
@@ -206,7 +206,7 @@ describe('AMQP Transport binding: measures', function() {
         });
 
         it('should silently ignore the error (without crashing)', function(done) {
-            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs', new Buffer('notAULPayload '));
+            channel.publish(config.amqp.exchange, '.1234.MQTT_2.attrs', Buffer.from('notAULPayload '));
 
             setTimeout(function() {
                 done();
@@ -231,7 +231,7 @@ describe('AMQP Transport binding: measures', function() {
             channel.publish(
                 config.amqp.exchange,
                 '.1234.MQTT_2.attrs',
-                new Buffer(
+                Buffer.from(
                     JSON.stringify({
                         a: '23',
                         b: '98'

--- a/test/unit/ngsiv2/amqpBinding-test2.js
+++ b/test/unit/ngsiv2/amqpBinding-test2.js
@@ -125,7 +125,7 @@ describe('AMQP Transport binding: multiple measures', function () {
             channel.publish(
                 config.amqp.exchange,
                 '.1234.MQTT_2.attrs',
-                new Buffer(JSON.stringify([{ a: '23' }, { a: '25' }]))
+                Buffer.from(JSON.stringify([{ a: '23' }, { a: '25' }]))
             );
 
             setTimeout(function () {
@@ -162,7 +162,7 @@ describe('AMQP Transport binding: multiple measures', function () {
             channel.publish(
                 config.amqp.exchange,
                 '.1234.MQTT_2.attrs',
-                new Buffer(
+                Buffer.from(
                     JSON.stringify([
                         {
                             a: '23',

--- a/test/unit/ngsiv2/commandsAmqp-test.js
+++ b/test/unit/ngsiv2/commandsAmqp-test.js
@@ -181,7 +181,7 @@ describe('AMQP Transport binding: commands', function() {
 
         it('should send an update request to the Context Broker', function(done) {
             channel.assertExchange(config.amqp.exchange, 'topic', config.amqp.options);
-            channel.publish(config.amqp.exchange, '.1234.MQTT_2.cmdexe', new Buffer('{"PING":"1234567890"}'));
+            channel.publish(config.amqp.exchange, '.1234.MQTT_2.cmdexe', Buffer.from('{"PING":"1234567890"}'));
 
             setTimeout(function() {
                 contextBrokerMock.done();


### PR DESCRIPTION
Replace `new Buffer()` with `Buffer.from()` - see https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues

This is has been an issue from Node 10 onwards.