### PR TITLE
use get configuration silently

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+- Avoid raise mongo alarm when a measure is not maching a group configuration
 - Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
-- Avoid raise mongo alarm when a measure is not maching a group configuration
+- Fix: avoid raise mongo alarm when a measure is not maching a group configuration
 - Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)

--- a/lib/iotaUtils.js
+++ b/lib/iotaUtils.js
@@ -216,7 +216,7 @@ function retrieveDevice(deviceId, apiKey, transport, callback) {
     } else {
         async.waterfall(
             [
-                apply(iotAgentLib.getConfiguration, config.getConfig().iota.defaultResource || '', apiKey),
+                apply(iotAgentLib.getConfigurationSilently, config.getConfig().iota.defaultResource || '', apiKey),
                 apply(findOrCreate, deviceId, transport),
                 apply(
                     iotAgentLib.mergeDeviceWithConfiguration,


### PR DESCRIPTION
needs https://github.com/telefonicaid/iotagent-node-lib/pull/1002

for avoid raise a mongo alarm like
```
time=2021-03-11T08:01:17.133Z | lvl=DEBUG | corr=2efa0453-e1a4-4fbc-9009-b8428edf08fd | trans=2efa0453-e1a4-4fbc-9009-b8428edf08fd | op=IOTAUL.Common.Binding | from=n/a | srv=n/a | subsrv=n/a | msg=message topic: /kz8i86f13itd4ibff87secf8c/test1/attrs/v | comp=IoTAgent
time=2021-03-11T08:01:17.134Z | lvl=DEBUG | corr=2efa0453-e1a4-4fbc-9009-b8428edf08fd | trans=2efa0453-e1a4-4fbc-9009-b8428edf08fd | op=IoTAgentNGSI.MongoDBGroupRegister | from=n/a | srv=n/a | subsrv=n/a | msg=Looking for group params ["resource","apikey"] with queryObj {"resource":"/iot/d","apikey":"kz8i86f13itd4ibff87secf8c"} | comp=IoTAgent
time=2021-03-11T08:01:17.148Z | lvl=DEBUG | corr=8080bf19-03fc-4e60-9753-861a680eb173 | trans=8080bf19-03fc-4e60-9753-861a680eb173 | op=IoTAgentNGSI.MongoDBGroupRegister | from=n/a | srv=n/a | subsrv=n/a | msg=Device group for fields [["resource","apikey"]] not found: [{"resource":"/iot/d","apikey":"kz8i86f13itd4ibff87secf8c"}] | comp=IoTAgent
time=2021-03-11T08:01:17.149Z | lvl=ERROR | corr=8080bf19-03fc-4e60-9753-861a680eb173 | trans=8080bf19-03fc-4e60-9753-861a680eb173 | op=IoTAgentNGSI.Alarms | from=n/a | srv=n/a | subsrv=n/a | msg=Raising [MONGO-ALARM]: {"name":"DEVICE_GROUP_NOT_FOUND","message":"Couldn\t find device group for fields: [\"resource\",\"apikey\"] and values: {\"resource\":\"/iot/d\",\"apikey\":\"kz8i86f13itd4ibff87secf8c\"}","code":404} | comp=IoTAgent
```

when just a randon measure arrives to agent:
```
mosquitto_pub -h localhost -t /<randon_apikey>/<randon_id>/attrs/v -m 28.92 -u iota -P mypassword
```

twin PR https://github.com/telefonicaid/iotagent-ul/pull/470