### PR TITLE
add content-type header

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Fix: missing conten-type: aplication/json header in the request sent to device command endpoint (HTTP transport)

--- a/lib/bindings/HTTPBinding.js
+++ b/lib/bindings/HTTPBinding.js
@@ -155,7 +155,8 @@ function executeCommand(apiKey, device, serializedPayload, callback) {
         body: serializedPayload,
         headers: {
             'fiware-service': device.service,
-            'fiware-servicepath': device.subservice
+            'fiware-servicepath': device.subservice,
+            'content-type': 'application/json'
         }
     };
 
@@ -324,7 +325,8 @@ function sendConfigurationToDevice(apiKey, deviceId, results, callback) {
             json: iotaUtils.createConfigurationNotification(results),
             headers: {
                 'fiware-service': device.service,
-                'fiware-servicepath': device.subservice
+                'fiware-servicepath': device.subservice,
+                'content-type': 'application/json'
             }
         };
 


### PR DESCRIPTION
Twin of PR https://github.com/telefonicaid/iotagent-json/pull/554 (for master), porting the same fix for releases/1.17.0