### PR TITLE
Fix NGSIv2 test logs

### DIFF
--- a/test/unit/ngsiv2/config-test.js
+++ b/test/unit/ngsiv2/config-test.js
@@ -45,7 +45,7 @@ config.amqp = {
 };
 
 config.iota = {
-    logLevel: 'DEBUG',
+    logLevel: 'FATAL',
     contextBroker: {
         host: '192.168.1.1',
         port: '1026',


### PR DESCRIPTION
After #567, the config test was changed from `FATAL` to `DEBUG` (here: https://github.com/telefonicaid/iotagent-json/pull/567/files#diff-32ba595ee3bda87b762afeb753381c650e3e1198af367953dd3b904a213ab849L48-R48). This introduced lot of "noise" on CI tests. This PR revert this change.