### PR TITLE
Task/check active attributes

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+Fix: check access to active attribute of device before use it (#576)
 Fix: processing configurations subscriptions in NGSIv2 (#563)

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -104,11 +104,13 @@ function extractAttributes(device, current) {
     const values = [];
 
     function checkAttributes(k) {
-        for (let j = 0; j < device.active.length; j++) {
-            const objectId = 'object_id';
-            const name = 'name';
-            if (k === 'TimeInstant' || device.active[j][objectId] === k || device.active[j][name] === k) {
-                return true;
+        if (device && device.active !== undefined) {
+            for (let j = 0; j < device.active.length; j++) {
+                const objectId = 'object_id';
+                const name = 'name';
+                if (k === 'TimeInstant' || device.active[j][objectId] === k || device.active[j][name] === k) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
related https://github.com/telefonicaid/iotagent-json/issues/576

fix for: 
time=2021-07-07T08:36:16.840Z | lvl=DEBUG | corr=761a6d32-a5c1-4944-bd1b-65d8f9c2636e | trans=761a6d32-a5c1-4944-bd1b-65d8f9c2636e | op=IoTAgentNGSI.DeviceService | from=n/a | srv=test | subsrv=/ | msg=deviceData after merge with conf: {"commands":[],"staticAttributes":[],"subscriptions":[],"_id":"60e56780cdab00ac6a7ecc78","creationDate":"2021-07-07T08:36:16.811Z","id":"dev3","type":"Sensor:Temperature","name":"Sensor:Temperature:dev3","service":"test","subservice":"/","transport":"HTTP","explicitAttrs":true,"__v":0,"lazy":null,"active":null} | comp=IoTAgent
time=2021-07-07T08:36:16.841Z | lvl=ERROR | corr=n/a | trans=n/a | op=IoTAgentNGSI.DomainControl | from=n/a | srv=n/a | subsrv=n/a | msg=TypeError: Cannot read property 'length' of null
    at checkAttributes (/Users/mpedraza/Documents/GitHub/iotagent-json/lib/commonBindings.js:107:43)
    at Object.extractAttributes (/Users/mpedraza/Documents/GitHub/iotagent-json/lib/commonBindings.js:118:46)
    at Function.processHTTPWithDevice (/Users/mpedraza/Documents/GitHub/iotagent-json/lib/bindings/HTTPBinding.js:245:41)
    at Domain.expandedFunction (/Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/iotagent-node-lib/lib/services/common/domain.js:171:23)
    at Domain.run (node:domain:373:15)
    at ensureSouthboundTransaction (/Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/iotagent-node-lib/lib/services/common/domain.js:154:22)
    at /Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/iotagent-node-lib/lib/services/common/domain.js:174:16
    at processDeviceMeasure (/Users/mpedraza/Documents/GitHub/iotagent-json/lib/bindings/HTTPBinding.js:290:59)
    at /Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/async/dist/async.js:473:16
    at next (/Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/async/dist/async.js:5329:29)
    at /Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/async/dist/async.js:969:16
    at mergeDeviceWithConfiguration (/Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/iotagent-node-lib/lib/services/devices/deviceService.js:183:5)
    at /Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/async/dist/async.js:66:19
    at nextTask (/Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/async/dist/async.js:5324:14)
    at next (/Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/async/dist/async.js:5331:9)
    at /Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/async/dist/async.js:969:16
    at Function.<anonymous> (/Users/mpedraza/Documents/GitHub/iotagent-json/lib/iotaUtils.js:200:21)
    at /Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/iotagent-node-lib/lib/services/common/alarmManagement.js:105:29
    at saveHandler (/Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/iotagent-node-lib/lib/services/devices/deviceRegistryMongoDB.js:111:13)
    at /Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/mongoose/lib/model.js:4599:16
    at /Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/mongoose/lib/utils.js:264:16
    at model.<anonymous> (/Users/mpedraza/Documents/GitHub/iotagent-json/node_modules/mongoose/lib/model.js:470:7) {
  domainThrown: true
} | comp=IoTAgent