### PR TITLE
fix content-type for get command

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Fix: content-type for get command in base of accept header (#582)
 Fix: processing configurations subscriptions in NGSIv2 (#563)
 Fix: check access to active attribute of device before use it (#576)
 Remove: obsolete Thinking Things plugin (#573)

--- a/lib/bindings/HTTPBinding.js
+++ b/lib/bindings/HTTPBinding.js
@@ -470,15 +470,26 @@ function returnCommands(req, res, next) {
     if (req.query && req.query.getCmd === '1') {
         iotAgentLib.commandQueue(req.device.service, req.device.subservice, req.deviceId, function (error, list) {
             if (error || !list || list.count === 0) {
-                res.status(200).send('');
+                if (req.accepts('json')) {
+                    res.status(200).send({});
+                } else {
+                    res.status(200).send('');
+                }
             } else {
-                res.status(200).send(JSON.stringify(list.commands.map(parseCommand).reduce(concatCommand, {})));
-
+                if (req.accepts('json')) {
+                    res.status(200).send(list.commands.map(parseCommand).reduce(concatCommand, {}));
+                } else {
+                    res.status(200).send(JSON.stringify(list.commands.map(parseCommand).reduce(concatCommand, {})));
+                }
                 process.nextTick(updateCommandStatus.bind(null, req.device, list.commands));
             }
         });
     } else {
-        res.status(200).send('');
+        if (req.accepts('json')) {
+            res.status(200).send({});
+        } else {
+            res.status(200).send('');
+        }
     }
 }
 


### PR DESCRIPTION
fix for https://github.com/telefonicaid/iotagent-json/issues/582

This PR uses accept header to build response content type for get commands