### PR TITLE
Create config.json

### DIFF
--- a/.github/fiware/config.json
+++ b/.github/fiware/config.json
@@ -1,0 +1,19 @@
+{
+    "enabler": "FIWARE IoT Agent for a JSON-based Protocol",
+    "chapter": "iotagents",
+    "academy": "iot-agents/idas",
+    "readthedocs": "fiware-iotagent-json",
+    "helpdesk": "",
+    "coveralls": "",
+    "github": ["telefonicaid/iotagent-json"],
+    "dockerregistry": ["hub.docker.com"],
+    "docker": ["telefonicaiot/iotagent-json"],
+    "email": "iot_support@tid.es",
+    "status": "full",
+    "compose": "",
+    "exclude": [""],
+    "stackexchange": ["fiware+iot"],
+    "unit-test": "",
+    "smoke-test": "",
+    "dockerfile": "https://github.com/telefonicaid/iotagent-json/blob/master/docker/Dockerfile"
+}


### PR DESCRIPTION
The FIWARE Foundation need a simple JSON file available in a standard location in each repo to be able to continue to make FIWARE Releases and improve the degree of cross-product integration testing that can occur. This change has been agreed by the TSC and has been added to the contribution requirements.

Please suggest or amend values where known.