### PR TITLE
Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - FIX: update polling when device is updated by adding endpoint (needs iota-node-lib >= 2.19) (#602)
 - FIX: Remove preprocess stripping of explicitAttrs (iotagent-node-lib#1151)
 - FIX: Add graceful shutdown listening to SIGINT (#606)
+- Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "dateformat": "3.0.3",
     "express": "~4.16.4",
     "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
-    "logops": "2.1.0",
+    "logops": "2.1.2",
     "mqtt": "3.0.0",
     "request": "2.88.0",
     "sinon": "~6.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "2.1.2",
     "mqtt": "3.0.0",
     "request": "2.88.0",


### PR DESCRIPTION
logops < 2.1.2 depends on colors dependency, which recently have a corruption problem: https://snyk.io/blog/open-source-npm-packages-colors-faker/