### PR TITLE
Remove JSON attribute from Request queries

### DIFF
--- a/test/unit/ngsiv2/commandsPolling-test.js
+++ b/test/unit/ngsiv2/commandsPolling-test.js
@@ -202,7 +202,6 @@ describe('HTTP Transport binding: polling commands', function () {
         const deviceRequestWithoutPayload = {
             url: 'http://localhost:' + config.http.port + '/iot/json',
             method: 'GET',
-            json: true,
             qs: {
                 i: 'MQTT_2',
                 k: '1234',


### PR DESCRIPTION
Removed old 'json:true' constructions present from legacy request library.

Related with https://github.com/telefonicaid/iotagent-node-lib/pull/1178
