### PR TITLE
upgrade async dep from 2.6.2 version to 2.6.4 due to security vulnera…

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+ Upgrade async dep from 2.6.1 to 2.6.4 due to security vulnerability (CWE-1321)
  Upgrade MQTT dep from 3.0.0 to 4.3.7
  Fix: ensure command QoS for MQTT is an integer
  Fix: ensure mqtt client_id is unique between reconnections to avoid reconnection loop (#650)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "keywords": [],
   "dependencies": {
     "amqplib": "~0.5.1",
-    "async": "2.6.1",
+    "async": "2.6.4",
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",


### PR DESCRIPTION
…bility (CWE-1321)

A vulnerability exists in Async through 3.2.1 for 3.x and through 2.6.3 for 2.x (fixed in 3.2.2 and 2.6.4), which could let a malicious user obtain privileges via the mapValues() method.