### PR TITLE
Update moment dep from 2.27 to 2.29.2 due to vulnerability

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+ Upgrade moment dep from 2.24.0 to 2.29.2 due to security vulnerability (CVE-2022-24785)
  Upgrade async dep from 2.6.1 to 2.6.4 due to security vulnerability (CWE-1321)
  Upgrade MQTT dep from 3.0.0 to 4.3.7
  Fix: ensure command QoS for MQTT is an integer

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
- Upgrade moment dep from 2.24.0 to 2.29.2 due to security vulnerability (CVE-2022-24785)
+ Upgrade moment dep from 2.27.0 to 2.29.2 due to security vulnerability (CVE-2022-24785)
  Upgrade async dep from 2.6.1 to 2.6.4 due to security vulnerability (CWE-1321)
  Upgrade MQTT dep from 3.0.0 to 4.3.7
  Fix: ensure command QoS for MQTT is an integer

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "proxyquire": "2.1.3",
     "remark-cli": "~8.0.1",
     "remark-preset-lint-recommended": "~4.0.1",
-    "moment": "~2.27.0",
+    "moment": "~2.29.2",
     "textlint": "~11.7.6",
     "textlint-rule-common-misspellings": "~1.0.1",
     "textlint-rule-terminology": "~2.1.4",


### PR DESCRIPTION
According with moment changelog between 2.27.0 to 2.29.2 there is only bugfixing
https://github.com/moment/moment/blob/develop/CHANGELOG.md

related https://github.com/telefonicaid/iotagent-node-lib/pull/1238