### PR TITLE
release 1.22.0_inst

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "body-parser": "1.18.3",
     "dateformat": "3.0.3",
     "express": "~4.16.4",
-    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#task/instrumentalize_mongo_alarms_about_group_release_2_21_0",
     "logops": "2.1.2",
     "mqtt": "4.3.7",
     "sinon": "~6.1.0",


### PR DESCRIPTION
Do not merge 
Just to create a 1.22.0 version based on iotagent-node-lib branch task/instrumentalize_mongo_alarms_about_group_release_2_21_0