### PR TITLE
ensure context srv and subsrv using device srv and subsrv processing measures

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: Dockerfile to include initial packages upgrade
+- Fix: Set service and subservice in logs when processing measures

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -179,6 +179,8 @@ function singleMeasure(apiKey, deviceId, attribute, device, parsedMessage) {
     ];
     config.getLogger().debug(context, 'values updates [%s]', JSON.stringify(values));
     iotAgentLib.update(device.name, device.type, '', values, device, function (error) {
+        context.service = device.service;
+        context.subservice = device.subservice;
         if (error) {
             config.getLogger().error(
                 context,
@@ -230,6 +232,8 @@ function multipleMeasures(apiKey, deviceId, device, messageObj) {
         }
 
         iotAgentLib.update(device.name, device.type, '', values, device, function (error) {
+            context.service = device.service;
+            context.subservice = device.subservice;
             if (error) {
                 config.getLogger().error(
                     context,


### PR DESCRIPTION
The logs where srv and subsrv are wrong is expected to be reproduced when a device has more than one geo:point attrs

![Screenshot from 2022-05-30 10-34-43](https://user-images.githubusercontent.com/983422/170952321-d1469d55-8f8b-4428-95e8-5c80dc9a73c0.png)

![Screenshot from 2022-05-30 10-35-50](https://user-images.githubusercontent.com/983422/170952516-ebd9bbf3-686c-4471-9a93-f8fe9a5e51ae.png)



time=2022-05-30T08:08:06.593Z | lvl=ERROR | corr=ef3f58df-8fda-480b-b15d-fb543396de40 | trans=ef3f58df-8fda-480b-b15d-fb543396de40 | op=IOTAJSON.HTTP.Binding | from=n/a | srv=smartcity | subsrv=/ | msg=MEASURES-002: Couldn't send the updated values to the Context Broker due to an error: {"name":"ENTITY_GENERIC_ERROR","message":"Error accesing entity data for device: device:disp6 of type: device","details":{"error":"NoResourcesAvailable","description":"You cannot use more than one geo location attribute when creating an entity. Use ignoreType metadata if you want to add additional informative locations."},"code":413} | comp=IoTAgent



https://fiware-orion.readthedocs.io/en/master/user/ngsiv2_implementation_notes.html#limit-to-attributes-for-entity-location