### PR TITLE
 handle errors mqttt binding ending client

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Fix: mqtt error handling was calling callback in loop (#679)

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -281,9 +281,7 @@ function start(callback) {
             /*jshint quotmark: double */
             config.getLogger().fatal("GLOBAL-002: Couldn't connect with MQTT broker: %j", e);
             /*jshint quotmark: single */
-            if (e.code === 'ENOTFOUND') {
-                mqttClient.end();
-            }
+            mqttClient.end();
         });
         mqttClient.on('message', commonBindings.mqttMessageHandler);
         mqttClient.on('connect', function (ack) {

--- a/lib/bindings/MQTTBinding.js
+++ b/lib/bindings/MQTTBinding.js
@@ -281,8 +281,8 @@ function start(callback) {
             /*jshint quotmark: double */
             config.getLogger().fatal("GLOBAL-002: Couldn't connect with MQTT broker: %j", e);
             /*jshint quotmark: single */
-            if (callback) {
-                callback(e);
+            if (e.code === 'ENOTFOUND') {
+                mqttClient.end();
             }
         });
         mqttClient.on('message', commonBindings.mqttMessageHandler);


### PR DESCRIPTION
fix for https://github.com/telefonicaid/iotagent-json/issues/679

This way, with default config, 5 tries for connect will be done before stop when an error of conection (ENOTFOUND, ECONNREFUSED or similar) is catched

Twin PR for UL agent is expected