### PR TITLE
Feature/amqps protocol

### DIFF
--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -136,8 +136,8 @@ These are the currently available MQTT configuration options:
     order versions) or without the slash. See
     [discussion](https://github.com/telefonicaid/iotagent-node-lib/issues/866).
 -   **clean**: this flag is by default true, set to false to receive QoS 1 and 2 messages while offline.
--   **clientId**: string ID which identifies client in mqtt broker. By default is using a string composed by a fixed prefix 
-    `iotajson_` and a random suffix, i.e. `iotajson_43bf8a3a`.
+-   **clientId**: string ID which identifies client in mqtt broker. By default is using a string composed by a fixed
+    prefix `iotajson_` and a random suffix, i.e. `iotajson_43bf8a3a`.
 
 TLS options (i.e. **ca**, **cert**, **key**, **rejectUnauthorized**) are directly linked with the ones supported by the
 [tls module of Node.js](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options).
@@ -147,6 +147,7 @@ TLS options (i.e. **ca**, **cert**, **key**, **rejectUnauthorized**) are directl
 The `config.amqp` section of the config file contains all the information needed to connect to the AMQP Broker from the
 IoT Agent. The following attributes are accepted:
 
+-   **protocol**: protocol to use for connecting with the AMQP broker (`amqp`, `amqps`). The default is `amqp`
 -   **host**: Host where the AMQP Broker is located.
 -   **port**: Port where the AMQP Broker is listening
 -   **username**: username that identifies the IOTA against the AMQP broker (optional).
@@ -202,6 +203,7 @@ The ones relating specific JSON bindings are described in the following table.
 | IOTA_MQTT_AVOID_LEADING_SLASH | mqtt.avoidLeadingSlash  |
 | IOTA_MQTT_CLEAN               | mqtt.clean              |
 | IOTA_MQTT_CLIENT_ID           | mqtt.clientId           |
+| IOTA_AMQP_PROTOCOL            | amqp.protocol           |
 | IOTA_AMQP_HOST                | amqp.host               |
 | IOTA_AMQP_PORT                | amqp.port               |
 | IOTA_AMQP_USERNAME            | amqp.username           |

--- a/lib/bindings/AMQPBinding.js
+++ b/lib/bindings/AMQPBinding.js
@@ -110,7 +110,7 @@ function start(callback) {
         retryTime = constants.AMQP_DEFAULT_RETRY_TIME;
     }
 
-    let uri = 'amqp://';
+    let uri = config.getConfig().amqp.protocol ? config.getConfig().amqp.protocol + `://` : 'amqp://';
     if (config.getConfig().amqp) {
         if (config.getConfig().amqp.username && config.getConfig().amqp.password) {
             uri += config.getConfig().amqp.username + ':' + config.getConfig().amqp.password + '@';

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -70,6 +70,7 @@ function processEnvironmentVariables() {
         'IOTA_MQTT_AVOID_LEADING_SLASH',
         'IOTA_MQTT_CLEAN',
         'IOTA_MQTT_CLIENT_ID',
+        'IOTA_AMQP_PROTOCOL',
         'IOTA_AMQP_HOST',
         'IOTA_AMQP_PORT',
         'IOTA_AMQP_USERNAME',
@@ -105,6 +106,7 @@ function processEnvironmentVariables() {
         'IOTA_MQTT_CLIENT_ID'
     ];
     const amqpVariables = [
+        'IOTA_AMQP_PROTOCOL',
         'IOTA_AMQP_HOST',
         'IOTA_AMQP_PORT',
         'IOTA_AMQP_USERNAME',
@@ -227,6 +229,10 @@ function processEnvironmentVariables() {
 
     if (anyIsSet(amqpVariables)) {
         config.amqp = {};
+    }
+
+    if (process.env.IOTA_AMQP_PROTOCOL) {
+        config.amqp.protocol = process.env.IOTA_AMQP_PROTOCOL;
     }
 
     if (process.env.IOTA_AMQP_HOST) {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "amqplib": "~0.5.1",
+    "amqplib": "~0.10.3",
     "async": "2.6.4",
     "body-parser": "1.20.0",
     "dateformat": "3.0.3",

--- a/test/unit/startup-test.js
+++ b/test/unit/startup-test.js
@@ -86,6 +86,7 @@ describe('Startup tests', function () {
 
     describe('When the AMQP transport is started with environment variables', function () {
         beforeEach(function () {
+            process.env.IOTA_AMQP_PROTOCOL = 'xxx';
             process.env.IOTA_AMQP_HOST = 'localhost';
             process.env.IOTA_AMQP_PORT = '9090';
             process.env.IOTA_AMQP_USERNAME = 'useramqp';
@@ -98,6 +99,7 @@ describe('Startup tests', function () {
         });
 
         afterEach(function () {
+            delete process.env.IOTA_AMQP_PROTOCOL;
             delete process.env.IOTA_AMQP_HOST;
             delete process.env.IOTA_AMQP_PORT;
             delete process.env.IOTA_AMQP_USERNAME;


### PR DESCRIPTION
Since we are going to use AMQP in a future project I changed the URI-generation a bit to enable TLS-connections. 
It does not yet support client-certificates, since that isn't strictly needed in my use-case but I thought maybe somebody else might be interested in AMQPS. 

I did it analogous to mqtts, even though that might confuse some people due to AMQP-Protocols 0.9.1 vs 1.0 being a very different thing. This still uses 0.9.1, nothing changed there.

The new Env would be: 
`- IOTA_AMQP_PROTOCOL=amqp` or `amqps`

Don't really know if the testing-part works as intended. Basically just c/p'ed from MQTT_PROTOCOL...