### PR TITLE
use node _lib refactor

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Align tests with iota-node-lib (v3.0) refactor

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "body-parser": "1.20.0",
     "dateformat": "3.0.3",
     "express": "4.18.1",
-    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#task/plugins_refactor",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "2.1.2",
     "mqtt": "4.3.7",
     "sinon": "~6.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "body-parser": "1.20.0",
     "dateformat": "3.0.3",
     "express": "4.18.1",
-    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#task/plugins_refactor",
     "logops": "2.1.2",
     "mqtt": "4.3.7",
     "sinon": "~6.1.0",

--- a/test/unit/ngsiv2/HTTP_reveice_measures-test.js
+++ b/test/unit/ngsiv2/HTTP_reveice_measures-test.js
@@ -204,8 +204,6 @@ describe('HTTP: Measure reception ', function () {
                 .reply(204);
 
             iotaJson.stop(function () {
-                config.iota.timestamp = true;
-                config.compressTimestamp = false;
                 iotaJson.start(config, function () {
                     request(provisionOptions, function (error, response, body) {
                         done();
@@ -214,10 +212,7 @@ describe('HTTP: Measure reception ', function () {
             });
         });
 
-        afterEach(function () {
-            config.iota.timestamp = false;
-            config.compressTimestamp = true;
-        });
+        afterEach(function () {});
 
         it('should send its value to the Context Broker', function (done) {
             request(optionsMeasure, function (error, result, body) {
@@ -277,8 +272,6 @@ describe('HTTP: Measure reception ', function () {
                 .reply(204);
 
             iotaJson.stop(function () {
-                config.iota.timestamp = true;
-                config.compressTimestamp = false;
                 iotaJson.start(config, function () {
                     request(provisionOptions, function (error, response, body) {
                         done();
@@ -287,10 +280,7 @@ describe('HTTP: Measure reception ', function () {
             });
         });
 
-        afterEach(function () {
-            config.iota.timestamp = false;
-            config.compressTimestamp = true;
-        });
+        afterEach(function () {});
 
         it('should send its value to the Context Broker', function (done) {
             request(optionsMeasure, function (error, result, body) {
@@ -350,8 +340,6 @@ describe('HTTP: Measure reception ', function () {
                 .reply(204);
 
             iotaJson.stop(function () {
-                config.iota.timestamp = true;
-                config.compressTimestamp = false;
                 iotaJson.start(config, function () {
                     request(provisionOptions, function (error, response, body) {
                         done();
@@ -360,10 +348,7 @@ describe('HTTP: Measure reception ', function () {
             });
         });
 
-        afterEach(function () {
-            config.iota.timestamp = false;
-            config.compressTimestamp = true;
-        });
+        afterEach(function () {});
 
         it('should send its value to the Context Broker', function (done) {
             request(optionsMeasure, function (error, result, body) {
@@ -423,8 +408,6 @@ describe('HTTP: Measure reception ', function () {
                 .reply(204);
 
             iotaJson.stop(function () {
-                config.iota.timestamp = true;
-                config.compressTimestamp = false;
                 iotaJson.start(config, function () {
                     request(provisionOptions, function (error, response, body) {
                         done();
@@ -433,10 +416,7 @@ describe('HTTP: Measure reception ', function () {
             });
         });
 
-        afterEach(function () {
-            config.iota.timestamp = false;
-            config.compressTimestamp = true;
-        });
+        afterEach(function () {});
 
         it('should send its value to the Context Broker', function (done) {
             request(optionsMeasure, function (error, result, body) {

--- a/test/unit/ngsiv2/HTTP_reveice_measures-test2.js
+++ b/test/unit/ngsiv2/HTTP_reveice_measures-test2.js
@@ -242,8 +242,6 @@ describe('HTTP: Measure reception ', function () {
                 .reply(204);
 
             iotaJson.stop(function () {
-                config.iota.timestamp = true;
-                config.compressTimestamp = false;
                 iotaJson.start(config, function () {
                     request(provisionOptions, function (error, response, body) {
                         done();
@@ -252,10 +250,7 @@ describe('HTTP: Measure reception ', function () {
             });
         });
 
-        afterEach(function () {
-            config.iota.timestamp = false;
-            config.compressTimestamp = true;
-        });
+        afterEach(function () {});
 
         it('should send its value to the Context Broker', function (done) {
             request(optionsMeasure, function (error, result, body) {
@@ -329,8 +324,6 @@ describe('HTTP: Measure reception ', function () {
                 .reply(204);
 
             iotaJson.stop(function () {
-                config.iota.timestamp = true;
-                config.compressTimestamp = false;
                 iotaJson.start(config, function () {
                     request(provisionOptions, function (error, response, body) {
                         done();
@@ -339,10 +332,7 @@ describe('HTTP: Measure reception ', function () {
             });
         });
 
-        afterEach(function () {
-            config.iota.timestamp = false;
-            config.compressTimestamp = true;
-        });
+        afterEach(function () {});
 
         it('should send its value to the Context Broker', function (done) {
             request(optionsMeasure, function (error, result, body) {

--- a/test/unit/ngsiv2/MQTT_commands_test.js
+++ b/test/unit/ngsiv2/MQTT_commands_test.js
@@ -146,7 +146,10 @@ describe('MQTT: Commands', function () {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartgondor')
                 .matchHeader('fiware-servicepath', '/gardens')
-                .post('/v2/op/update', utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json'))
+                .patch(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json')
+                )
                 .reply(204);
         });
 

--- a/test/unit/ngsiv2/commandsAmqp-test.js
+++ b/test/unit/ngsiv2/commandsAmqp-test.js
@@ -179,7 +179,10 @@ describe('AMQP Transport binding: commands', function () {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartgondor')
                 .matchHeader('fiware-servicepath', '/gardens')
-                .post('/v2/op/update', utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json'))
+                .patch(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus2.json')
+                )
                 .reply(204);
         });
 

--- a/test/unit/ngsiv2/contextRequests/timeInstantMeasures.json
+++ b/test/unit/ngsiv2/contextRequests/timeInstantMeasures.json
@@ -1,16 +1,10 @@
 {
   "humidity":{
     "type": "percent",
-    "value": "111222",
-    "metadata":{
-      "TimeInstant":{
-        "type": "DateTime",
-        "value": "20200222T222222"        
-      }
-    }
+    "value": "111222"
   },
   "TimeInstant":{
     "type": "DateTime",
-    "value": "20200222T222222"
+    "value": "+002020-02-22T22:22:22"
   }
 }

--- a/test/unit/ngsiv2/contextRequests/timeInstantMeasures2.json
+++ b/test/unit/ngsiv2/contextRequests/timeInstantMeasures2.json
@@ -1,16 +1,10 @@
 {
   "humidity":{
     "type": "percent",
-    "value": "111333",
-    "metadata":{
-      "TimeInstant":{
-        "type": "DateTime",
-        "value": "20200222T222222"        
-      }
-    }
+    "value": "111333"
   },
   "TimeInstant":{
     "type": "DateTime",
-    "value": "20200222T222222"
+    "value": "+002020-02-22T22:22:22"
   }
 }

--- a/test/unit/ngsiv2/contextRequests/timeInstantMeasures3.json
+++ b/test/unit/ngsiv2/contextRequests/timeInstantMeasures3.json
@@ -1,26 +1,14 @@
 {
   "humidity":{
     "type": "percent",
-    "value": "111222",
-    "metadata":{
-      "TimeInstant":{
-        "type": "DateTime",
-        "value": "20200222T222222"        
-      }
-    }
+    "value": "111222"
   },
   "pressure":{
     "type": "string",
-    "value": "20",
-    "metadata":{
-      "TimeInstant":{
-        "type": "DateTime",
-        "value": "20200222T222222"
-      }
-    }
+    "value": "20"
   },
   "TimeInstant":{
     "type": "DateTime",
-    "value": "20200222T222222"
+    "value": "+002020-02-22T22:22:22"
   }
 }

--- a/test/unit/ngsiv2/contextRequests/timestampAliasMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/timestampAliasMeasure.json
@@ -1,26 +1,14 @@
 {
   "humidity":{
     "type":"degrees",
-    "value":"32",
-    "metadata":{
-      "TimeInstant":{
-        "type":"DateTime",
-        "value":"20071103T131805"
-      }
-    }
+    "value":"32"
   },
   "temperature":{
     "type":"celsius",
-    "value":"87",
-    "metadata":{
-      "TimeInstant":{
-        "type":"DateTime",
-        "value":"20071103T131805"
-      }
-    }
+    "value":"87"
   },
   "TimeInstant":{
     "type":"DateTime",
-    "value":"20071103T131805"
+    "value": "+002007-11-03T13:18:05"
   }
 }

--- a/test/unit/ngsiv2/contextRequests/timestampMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/timestampMeasure.json
@@ -1,26 +1,14 @@
 {
   "humidity":{
     "type": "degrees",
-    "value": "32",
-    "metadata": {
-      "TimeInstant":{
-        "type": "DateTime",
-        "value": "20071103T131805"
-      }
-    }
+    "value": "32"
   },
   "temperature":{
     "type": "celsius",
-    "value": "87",  
-    "metadata": {
-      "TimeInstant":{
-        "type": "DateTime",
-        "value": "20071103T131805"
-      }
-    }  
+    "value": "87"
   },
   "TimeInstant":{
     "type": "DateTime",
-    "value": "20071103T131805"
+    "value": "+002007-11-03T13:18:05"
   }
 }

--- a/test/unit/ngsiv2/contextRequests/timestampMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/timestampMeasure2.json
@@ -1,26 +1,14 @@
 {
   "humidity":{
     "type": "degrees",
-    "value": "33",
-    "metadata": {
-      "TimeInstant":{
-        "type": "DateTime",
-        "value": "20071103T131805"
-      }
-    }
+    "value": "33"
   },
   "temperature":{
     "type": "celsius",
-    "value": "89",  
-    "metadata": {
-      "TimeInstant":{
-        "type": "DateTime",
-        "value": "20071103T131805"
-      }
-    }  
+    "value": "89"
   },
   "TimeInstant":{
     "type": "DateTime",
-    "value": "20071103T131805"
+    "value": "+002007-11-03T13:18:05"
   }
 }

--- a/test/unit/ngsiv2/contextRequests/updateStatus2.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus2.json
@@ -1,15 +1,10 @@
 {
-        "actionType": "update",
-        "entities": [{
-                "id": "Second MQTT Device",
-                "type": "AnMQTTDevice",
-                "PING_status": {
-                        "type": "commandStatus",
-                        "value": "OK"
-                },
-                "PING_info": {
-                        "type": "commandResult",
-                        "value": "1234567890"
-                }
-        }]
+    "PING_status": {
+        "type": "commandStatus",
+        "value": "OK"
+    },
+    "PING_info": {
+        "type": "commandResult",
+        "value": "1234567890"
+    }
 }


### PR DESCRIPTION
PR to test agent with new iota node lib:
If timestamp is provided as measure then no metadata with timestamp is added to attributes.
Compression about timestamp is always checked in iotagent-node-lib, so always is uncompressed

iota-node-lib deb should be set to #master before merge