### PR TITLE
split test response equivalent but with different order

### DIFF
--- a/test/unit/ngsiv2/HTTP_reveice_measures-test.js
+++ b/test/unit/ngsiv2/HTTP_reveice_measures-test.js
@@ -266,7 +266,7 @@ describe('HTTP: Measure reception ', function () {
                 .matchHeader('fiware-servicepath', '/gardens')
                 .patch(
                     '/v2/entities/e0130101/attrs',
-                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/timeInstantMeasures.json')
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/timeInstantMeasuresB.json')
                 )
                 .query({ type: 'sensor' })
                 .reply(204);

--- a/test/unit/ngsiv2/contextRequests/timeInstantMeasuresB.json
+++ b/test/unit/ngsiv2/contextRequests/timeInstantMeasuresB.json
@@ -1,0 +1,16 @@
+{
+    "TimeInstant":{
+        "type": "DateTime",
+        "value": "+002020-02-22T22:22:22"
+    },
+    "humidity":{
+        "type": "percent",
+        "value": "111222",
+        "metadata": {
+            "TimeInstant": {
+                "type": "DateTime",
+                "value": "+002020-02-22T22:22:22"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Needs: https://github.com/telefonicaid/iotagent-node-lib/pull/1362


equivalent to:

```
{
  "humidity":{
    "type": "percent",
      "value": "111222",
      "metadata": {
          "TimeInstant":{
              "type": "DateTime",
              "value": "+002020-02-22T22:22:22"
          }
      }
  },
  "TimeInstant":{
    "type": "DateTime",
    "value": "+002020-02-22T22:22:22"
  }
}

```