### PR TITLE
Add plain text `payloadType` command return option

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-Add: Support new commands payloadType - plain text 
+- Add: support new commands payloadType "text" (for plain text) (#716)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+Add: Support new commands payloadType - plain text 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -517,7 +517,7 @@ the following meanings:
     stringified (avoiding the doble quotes).
 -   **json**: This is the default case. Payload will be stringify from a JSON.
 
-The following table shows the values the payload takes depending on the `payloadType`:
+The following table shows some examples of values the payload takes depending on the `payloadType`:
 
 | payloadType      | cmd value                | payload represented in hex                                    | payload represented in ASCII |
 | ---------------- | ------------------------ | ------------------------------------------------------------- | ---------------------------- |

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -519,17 +519,17 @@ the following meanings:
 
 The following table shows the values the payload takes depending on the `payloadType`:
 
-| payloadType      | cmd value              | payload represented in hex                                  | payload represented in ASCII |
-| ---------------- | ---------------------- | ----------------------------------------------------------- | ---------------------------- |
-| binaryfromstring | '12345'                | 0x 31 32 33 34 35                                           | 12345                        |
-| binaryfromstring | '484F4C41'             | 34 38 34 46 34 43 34 31                                     | 484F4C41                     |
-| binaryfromstring | ['1', '23', '2', '50'] | 31 2c 32 33 2c 32 2c 35 30                                  | 1,23,2,50                    |
-| binaryfromhex    | '12345'                | 0x 12 34                                                    | ☐4                           |
-| binaryfromhex    | '484F4C41'             | 0x 48 4F 4C 41                                              | HOLA                         |
-| binaryfromhex    | ['1', '23', '2', '50'] | 0x 01 17 02 32                                              | ☐☐☐2                         |
-| binaryfromjson   | '12345'                | 0x 22 31 32 33 34 35 22                                     | "12345"                      |
-| binaryfromjson   | '484F4C41'             | 0x 22 34 38 34 46 34 43 34 31 22                            | "484F4C41"                   |
-| binaryfromjson   | ['1', '23', '2', '50'] | 0x 5b 22 31 22 2c 22 32 33 22 2c 22 32 22 2c 22 35 30 22 5d | ["1","23","2","50"]          |
+| payloadType      | cmd value                | payload represented in hex                                    | payload represented in ASCII |
+| ---------------- | ------------------------ | ------------------------------------------------------------- | ---------------------------- |
+| binaryfromstring | `'12345'`                | `0x 31 32 33 34 35`                                           | `12345`                      |
+| binaryfromstring | `'484F4C41'`             | `0x 34 38 34 46 34 43 34 31`                                  | `484F4C41`                   |
+| binaryfromstring | `['1', '23', '2', '50']` | `0x 31 2c 32 33 2c 32 2c 35 30`                               | `1,23,2,50`                  |
+| binaryfromhex    | `'12345'`                | `0x 12 34`                                                    | `☐4`                         |
+| binaryfromhex    | `'484F4C41'`             | `0x 48 4F 4C 41`                                              | `HOLA`                       |
+| binaryfromhex    | `['1', '23', '2', '50']` | `0x 01 17 02 32`                                              | `☐☐☐2`                       |
+| binaryfromjson   | `'12345'`                | `0x 22 31 32 33 34 35 22`                                     | `"12345"`                    |
+| binaryfromjson   | `'484F4C41'`             | `0x 22 34 38 34 46 34 43 34 31 22`                            | `"484F4C41"`                 |
+| binaryfromjson   | `['1', '23', '2', '50']` | `0x 5b 22 31 22 2c 22 32 33 22 2c 22 32 22 2c 22 35 30 22 5d` | `["1","23","2","50"]`        |
 
 _Note that `☐` represents a non-printable character_
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -513,7 +513,25 @@ the following meanings:
 -   **binaryfromstring**: Payload will transformed into a be Buffer after read it from a string.
 -   **binaryfromhex**: Payload will transformed into a be Buffer after read it from a string hex.
 -   **binaryfromjson**: Payload will transformed into a be Buffer after read it from a JSON string.
+-   **text**: Payload will be read from a string. This differs from the default case in that the payload will not be
+    stringified (avoiding the doble quotes).
 -   **json**: This is the default case. Payload will be stringify from a JSON.
+
+The following table shows the values the payload takes depending on the `payloadType`:
+
+| payloadType      | cmd value              | payload represented in hex                                  | payload represented in ASCII |
+| ---------------- | ---------------------- | ----------------------------------------------------------- | ---------------------------- |
+| binaryfromstring | '12345'                | 0x 31 32 33 34 35                                           | 12345                        |
+| binaryfromstring | '484F4C41'             | 34 38 34 46 34 43 34 31                                     | 484F4C41                     |
+| binaryfromstring | ['1', '23', '2', '50'] | 31 2c 32 33 2c 32 2c 35 30                                  | 1,23,2,50                    |
+| binaryfromhex    | '12345'                | 0x 12 34                                                    | ☐4                           |
+| binaryfromhex    | '484F4C41'             | 0x 48 4F 4C 41                                              | HOLA                         |
+| binaryfromhex    | ['1', '23', '2', '50'] | 0x 01 17 02 32                                              | ☐☐☐2                         |
+| binaryfromjson   | '12345'                | 0x 22 31 32 33 34 35 22                                     | "12345"                      |
+| binaryfromjson   | '484F4C41'             | 0x 22 34 38 34 46 34 43 34 31 22                            | "484F4C41"                   |
+| binaryfromjson   | ['1', '23', '2', '50'] | 0x 5b 22 31 22 2c 22 32 33 22 2c 22 32 22 2c 22 35 30 22 5d | ["1","23","2","50"]          |
+
+_Note that `☐` represents a non-printable character_
 
 Moreover a command could define a `contentType` in their definnition with the aim to set `content-type` header for http
 transport in command. Default value will be `application/json` but other valids content-type could be: `text/plain`,

--- a/lib/commandHandler.js
+++ b/lib/commandHandler.js
@@ -51,6 +51,9 @@ function serializedPayloadCommand(payload, command) {
             case 'binaryfromjson': // used by AMQP transport
                 serialized = Buffer.from(JSON.stringify(payload));
                 break;
+            case 'text':
+                serialized = payload;
+                break;
             case 'json': // passthrough
             default:
                 serialized = JSON.stringify(payload);

--- a/test/deviceProvisioning/provisionCommand1.json
+++ b/test/deviceProvisioning/provisionCommand1.json
@@ -11,6 +11,23 @@
         {
           "name": "PING",
           "type": "command"
+        },
+        {
+          "name": "EXPRESSION_CMD",
+          "type": "command",
+          "expression" : "EXPRESSION_CMD | replacestr('Text','Expression')"
+        },
+        {
+          "name": "PAYLOAD_TYPE_1",
+          "type": "command",
+          "expression" : "PAYLOAD_TYPE_1",
+          "payloadType": "binaryfromhex"
+        },
+        {
+          "name": "PAYLOAD_TYPE_2",
+          "type": "command",
+          "expression" : "PAYLOAD_TYPE_2",
+          "payloadType": "text"
         }
       ]
     }

--- a/test/unit/ngsiv2/MQTT_commands_test.js
+++ b/test/unit/ngsiv2/MQTT_commands_test.js
@@ -261,14 +261,15 @@ describe('MQTT: Commands', function () {
                 payload = data.toString();
             });
 
-            (commandOptions.json = utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand5.json')),
-                request(commandOptions, function (error, response, body) {
-                    setTimeout(function () {
-                        should.exist(payload);
-                        payload.should.equal(commandMsg);
-                        done();
-                    }, 100);
-                });
+            commandOptions.json = utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand5.json');
+
+            request(commandOptions, function (error, response, body) {
+                setTimeout(function () {
+                    should.exist(payload);
+                    payload.should.equal(commandMsg);
+                    done();
+                }, 100);
+            });
         });
 
         it('text - should publish the transformed command information in the MQTT topic', function (done) {
@@ -279,14 +280,15 @@ describe('MQTT: Commands', function () {
                 payload = data.toString();
             });
 
-            (commandOptions.json = utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand6.json')),
-                request(commandOptions, function (error, response, body) {
-                    setTimeout(function () {
-                        should.exist(payload);
-                        payload.should.equal(commandMsg);
-                        done();
-                    }, 100);
-                });
+            commandOptions.json = utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand6.json');
+
+            request(commandOptions, function (error, response, body) {
+                setTimeout(function () {
+                    should.exist(payload);
+                    payload.should.equal(commandMsg);
+                    done();
+                }, 100);
+            });
         });
     });
 });

--- a/test/unit/ngsiv2/MQTT_commands_test.js
+++ b/test/unit/ngsiv2/MQTT_commands_test.js
@@ -88,7 +88,7 @@ describe('MQTT: Commands', function () {
         async.series([iotAgentLib.clearAll, iotagentMqtt.stop], done);
     });
 
-    describe('When a command arrive to the Agent for a device with the MQTT_UL protocol', function () {
+    describe('When a command arrive to the Agent for a device with the MQTT_JSON protocol', function () {
         const commandOptions = {
             url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
             method: 'POST',
@@ -160,6 +160,133 @@ describe('MQTT: Commands', function () {
                     done();
                 }, 200);
             });
+        });
+    });
+
+    describe('When a command with expression arrives to the Agent for a device with the MQTT_JSON protocol', function () {
+        const commandOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand4.json'),
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        beforeEach(function () {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .patch(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus7.json')
+                )
+                .reply(204);
+        });
+
+        it('should return a 204 OK without errors', function (done) {
+            request(commandOptions, function (error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+                done();
+            });
+        });
+        it('should update the status in the Context Broker', function (done) {
+            request(commandOptions, function (error, response, body) {
+                contextBrokerMock.done();
+                done();
+            });
+        });
+        it('should publish the transformed command information in the MQTT topic', function (done) {
+            const commandMsg = '"command Expression"';
+            let payload;
+
+            mqttClient.on('message', function (topic, data) {
+                payload = data.toString();
+            });
+
+            request(commandOptions, function (error, response, body) {
+                setTimeout(function () {
+                    should.exist(payload);
+                    payload.should.equal(commandMsg);
+                    done();
+                }, 100);
+            });
+        });
+    });
+
+    describe('When a command with payloadtype arrives to the Agent for a device with the MQTT_JSON protocol', function () {
+        const commandOptions = {
+            url: 'http://localhost:' + config.iota.server.port + '/v2/op/update',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand5.json'),
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        beforeEach(function () {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .patch(
+                    '/v2/entities/Second%20MQTT%20Device/attrs?type=AnMQTTDevice',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateStatus8.json')
+                )
+                .reply(204);
+        });
+
+        it('should return a 204 OK without errors', function (done) {
+            request(commandOptions, function (error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(204);
+                done();
+            });
+        });
+
+        it('should update the status in the Context Broker', function (done) {
+            request(commandOptions, function (error, response, body) {
+                contextBrokerMock.done();
+                done();
+            });
+        });
+
+        it('binaryfromhex - should publish the transformed command information in the MQTT topic', function (done) {
+            const commandMsg = 'HOLA';
+            let payload;
+
+            mqttClient.on('message', function (topic, data) {
+                payload = data.toString();
+            });
+
+            (commandOptions.json = utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand5.json')),
+                request(commandOptions, function (error, response, body) {
+                    setTimeout(function () {
+                        should.exist(payload);
+                        payload.should.equal(commandMsg);
+                        done();
+                    }, 100);
+                });
+        });
+
+        it('text - should publish the transformed command information in the MQTT topic', function (done) {
+            const commandMsg = 'myText';
+            let payload;
+
+            mqttClient.on('message', function (topic, data) {
+                payload = data.toString();
+            });
+
+            (commandOptions.json = utils.readExampleFile('./test/unit/ngsiv2/contextRequests/updateCommand6.json')),
+                request(commandOptions, function (error, response, body) {
+                    setTimeout(function () {
+                        should.exist(payload);
+                        payload.should.equal(commandMsg);
+                        done();
+                    }, 100);
+                });
         });
     });
 });

--- a/test/unit/ngsiv2/contextRequests/updateCommand4.json
+++ b/test/unit/ngsiv2/contextRequests/updateCommand4.json
@@ -1,0 +1,13 @@
+{
+  "actionType": "update",
+  "entities": [
+    {
+      "id": "Second MQTT Device",
+      "type": "AnMQTTDevice",
+      "EXPRESSION_CMD": {
+        "type": "command",
+        "value": "command Text"
+      }
+    }
+  ]
+}

--- a/test/unit/ngsiv2/contextRequests/updateCommand5.json
+++ b/test/unit/ngsiv2/contextRequests/updateCommand5.json
@@ -1,0 +1,13 @@
+{
+  "actionType": "update",
+  "entities": [
+    {
+      "id": "Second MQTT Device",
+      "type": "AnMQTTDevice",
+      "PAYLOAD_TYPE_1": {
+        "type": "command",
+        "value": "484F4C41"
+      }
+    }
+  ]
+}

--- a/test/unit/ngsiv2/contextRequests/updateCommand6.json
+++ b/test/unit/ngsiv2/contextRequests/updateCommand6.json
@@ -1,0 +1,13 @@
+{
+  "actionType": "update",
+  "entities": [
+    {
+      "id": "Second MQTT Device",
+      "type": "AnMQTTDevice",
+      "PAYLOAD_TYPE_2": {
+        "type": "command",
+        "value": "myText"
+      }
+    }
+  ]
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatus7.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus7.json
@@ -1,0 +1,6 @@
+{
+  "EXPRESSION_CMD_status": {
+    "type": "commandStatus",
+    "value": "PENDING"
+  }
+}

--- a/test/unit/ngsiv2/contextRequests/updateStatus8.json
+++ b/test/unit/ngsiv2/contextRequests/updateStatus8.json
@@ -1,0 +1,6 @@
+{
+  "PAYLOAD_TYPE_1_status": {
+    "type": "commandStatus",
+    "value": "PENDING"
+  }
+}


### PR DESCRIPTION
This PR solves https://github.com/telefonicaid/iotagent-json/issues/716

It also adds: 
- tests for MQTT CMD expressions
- tests for MQTT CMD `payloadType` functionality
- Examples to `payloadType` doc