### PR TITLE
Update commonBindings.js: remove parsedMessageError

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Remove: legacy code about unused parsedMessageError flag

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -49,7 +49,6 @@ const config = require('./configService');
  */
 function parseMessage(message) {
     let parsedMessage;
-    let parsedMessageError = false;
     let messageArray;
 
     const stringMessage = message.toString();
@@ -66,9 +65,6 @@ function parseMessage(message) {
         messageArray.push(parsedMessage);
     }
 
-    if (parsedMessageError) {
-        config.getLogger().error(context, 'MEASURES-003: Impossible to handle malformed message: %s', message);
-    }
     config.getLogger().debug(context, 'parserMessage array: %s', messageArray);
     return messageArray;
 }


### PR DESCRIPTION
legacy code not used