### PR TITLE
add metadata to ngsild payload measure + doc 

### DIFF
--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -246,7 +246,7 @@ Example of these `ngsild` payloads are the following ones:
 Some additional considerations to take into account:
 
 -   In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
--   The `type` of the attribute is the one used in the provision of the attribute, not the one in the measure. The execption is the autoprovisioned devices case, in which case the `type` of the attribute is taken from the measure (given the attribte lacks proviosioned type). In this latter case, if the attribute `type` is not included in the measure the [explicit type omission rules for Context Broker](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#partial-representations) are also taken into account in this case.
+-   The `type` of the attribute is the one used in the provision of the attribute, not the one in the measure. The exception is the autoprovisioned devices case, in which case the `type` of the attribute is taken from the measure (given the attribute lacks proviosioned type). In this latter case, if the attribute `type` is not included in the measure the [explicit type omission rules for Context Broker](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#partial-representations) are also taken into account in this case.
 -   In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
 
 ##### SOAP-XML Measure reporting

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -245,8 +245,8 @@ Example of these `ngsild` payloads are the following ones:
 
 Some additional considerations to take into account:
 
--   * In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
--   * In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
+-   In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
+-   In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata      in the entity corresponding to the measure at Context Broker.
 
 ##### SOAP-XML Measure reporting
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -246,7 +246,8 @@ Example of these `ngsild` payloads are the following ones:
 Some additional considerations to take into account:
 
 -   In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
--   In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata      in the entity corresponding to the measure at Context Broker.
+-   The `type` of the attribute is the one used in the provision of the attribute, not the one in the measure. The execption is the autoprovisioned devices case, in which case the `type` of the attribute is taken from the measure (given the attribte lacks proviosioned type). In this latter case, if the attribute `type` is not included in the measure the [explicit type omission rules for Context Broker](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#partial-representations) are also taken into account in this case.
+-   In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
 
 ##### SOAP-XML Measure reporting
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -243,7 +243,7 @@ Example of these `ngsild` payloads are the following ones:
 }
 ```
 
-Some additional consideration to take into account:
+Some additional considerations to take into account:
 
 * In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
 * In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -247,7 +247,7 @@ Some additional considerations to take into account:
 
 -   In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
 -   The `type` of the attribute is the one used in the provision of the attribute, not the one in the measure. The exception is the autoprovisioned devices case, in which case the `type` of the attribute is taken from the measure (given the attribute lacks proviosioned type). In this latter case, if the attribute `type` is not included in the measure the [explicit type omission rules for Context Broker](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#partial-representations) are also taken into account in this case.
--   In the case of NGSI-LD, fields different from `type`, `value` or `object` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
+-   In the case of NGSI-LD, fields different from `type`, `value` or `object` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker. Note IOTA doesn't provide the `type` for that metadata, so the Context Broker applies [a default type based in the metadat `value` JSON type](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#partial-representations).
 
 ##### SOAP-XML Measure reporting
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -247,7 +247,7 @@ Some additional considerations to take into account:
 
 -   In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
 -   The `type` of the attribute is the one used in the provision of the attribute, not the one in the measure. The exception is the autoprovisioned devices case, in which case the `type` of the attribute is taken from the measure (given the attribute lacks proviosioned type). In this latter case, if the attribute `type` is not included in the measure the [explicit type omission rules for Context Broker](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#partial-representations) are also taken into account in this case.
--   In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
+-   In the case of NGSI-LD, fields different from `type`, `value` or `object` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
 
 ##### SOAP-XML Measure reporting
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -245,8 +245,8 @@ Example of these `ngsild` payloads are the following ones:
 
 Some additional considerations to take into account:
 
-* In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
-* In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
+-  In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
+-  In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
 
 ##### SOAP-XML Measure reporting
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -247,7 +247,7 @@ Some additional considerations to take into account:
 
 -   In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
 -   The `type` of the attribute is the one used in the provision of the attribute, not the one in the measure. The exception is the autoprovisioned devices case, in which case the `type` of the attribute is taken from the measure (given the attribute lacks proviosioned type). In this latter case, if the attribute `type` is not included in the measure the [explicit type omission rules for Context Broker](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#partial-representations) are also taken into account in this case.
--   In the case of NGSI-LD, fields different from `type`, `value` or `object` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker. Note IOTA doesn't provide the `type` for that metadata, so the Context Broker applies [a default type based in the metadat `value` JSON type](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#partial-representations).
+-   In the case of NGSI-LD, fields different from `type`, `value` or `object` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker. Note IOTA doesn't provide the `type` for that metadata, so the Context Broker applies [a default type based in the metadata `value` JSON type](https://github.com/telefonicaid/fiware-orion/blob/master/doc/manuals/orion-api.md#partial-representations).
 
 ##### SOAP-XML Measure reporting
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -245,8 +245,8 @@ Example of these `ngsild` payloads are the following ones:
 
 Some additional considerations to take into account:
 
--  In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
--  In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
+-   * In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
+-   * In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
 
 ##### SOAP-XML Measure reporting
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -243,7 +243,10 @@ Example of these `ngsild` payloads are the following ones:
 }
 ```
 
-Note that array of entities are handled as a multiple measure, each entity is a measure.
+Some additional consideration to take into account:
+
+* In the case of array of entities, they are handled as a multiple measure, i.e. each entity is a measure.
+* In the case of NGSI-LD, fields different from `type` or `value` (e.g. `observedAt` in the examples above) are include as NGSI-v2 metadata in the entity corresponding to the measure at Context Broker.
 
 ##### SOAP-XML Measure reporting
 

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -73,9 +73,9 @@ function parseMessage(message) {
  * Find the attribute given by its name between all the active attributes of the given device, returning its type, or
  * null otherwise.
  *
- * @param {String} attribute        Name of the attribute to find.
- * @param {Object} device           Device object containing all the information about a device.
- * @param {measureType} type        Type of measure attribute according with measure
+ * @param {String}      attribute   Name of the attribute to find.
+ * @param {Object}      device      Device object containing all the information about a device.
+ * @param {measureType} type        Type of measure attribute according with measure when available (ngsiv2 and ngsild measures)
  * @return {String}                 String identifier of the attribute type.
  */
 function guessType(attribute, device, measureType) {

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -133,25 +133,13 @@ function extractAttributes(device, current, payloadType) {
                                     ent.value = entity[k].object;
                                 }
                             }
-                            if (entity[k].createdAt) {
-                                if (ent.metadata) {
-                                    ent.metadata.createdAt = entity[k].createdAt;
-                                } else {
-                                    ent.metadata = { createdAt: entity[k].createdAt };
-                                }
-                            }
-                            if (entity[k].modifiedAt) {
-                                if (ent.metadata) {
-                                    ent.metadata.modifiedAt = entity[k].modifiedAt;
-                                } else {
-                                    ent.metadata = { modifiedAt: entity[k].modifiedAt };
-                                }
-                            }
-                            if (entity[k].observedAt) {
-                                if (ent.metadata) {
-                                    ent.metadata.observedAt = entity[k].observedAt;
-                                } else {
-                                    ent.metadata = { observedAt: entity[k].observedAt };
+                            // Add other stuff as metadata
+                            for (let key in entity[k]) {
+                                if (!['type', 'value', 'object'].includes(key.toLowerCase())) {
+                                    if (!ent.metadata) {
+                                        ent.metadata = {};
+                                    }
+                                    ent.metadata[key] = entity[k][key];
                                 }
                             }
                         }

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -139,7 +139,7 @@ function extractAttributes(device, current, payloadType) {
                                     if (!ent.metadata) {
                                         ent.metadata = {};
                                     }
-                                    ent.metadata[key] = entity[k][key];
+                                    ent.metadata[key] = { "value": entity[k][key] };
                                 }
                             }
                         }

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -133,6 +133,27 @@ function extractAttributes(device, current, payloadType) {
                                     ent.value = entity[k].object;
                                 }
                             }
+                            if (entity[k].createdAt) {
+                                if (ent.metadata) {
+                                    ent.metadata.createdAt = entity[k].createdAt;
+                                } else {
+                                    ent.metadata = { createdAt: entity[k].createdAt };
+                                }
+                            }
+                            if (entity[k].modifiedAt) {
+                                if (ent.metadata) {
+                                    ent.metadata.modifiedAt = entity[k].modifiedAt;
+                                } else {
+                                    ent.metadata = { modifiedAt: entity[k].modifiedAt };
+                                }
+                            }
+                            if (entity[k].observedAt) {
+                                if (ent.metadata) {
+                                    ent.metadata.observedAt = entity[k].observedAt;
+                                } else {
+                                    ent.metadata = { observedAt: entity[k].observedAt };
+                                }
+                            }
                         }
                         valuesEntity.push(ent);
                     }

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -75,9 +75,10 @@ function parseMessage(message) {
  *
  * @param {String} attribute        Name of the attribute to find.
  * @param {Object} device           Device object containing all the information about a device.
+ * @param {measureType} type        Type of measure attribute according with measure
  * @return {String}                 String identifier of the attribute type.
  */
-function guessType(attribute, device) {
+function guessType(attribute, device, measureType) {
     if (device.active) {
         for (let i = 0; i < device.active.length; i++) {
             if (device.active[i].name === attribute) {
@@ -89,7 +90,11 @@ function guessType(attribute, device) {
     if (attribute === constants.TIMESTAMP_ATTRIBUTE) {
         return constants.TIMESTAMP_TYPE_NGSI2;
     }
-    return constants.DEFAULT_ATTRIBUTE_TYPE;
+    if (measureType) {
+        return measureType;
+    } else {
+        return constants.DEFAULT_ATTRIBUTE_TYPE;
+    }
 }
 
 function extractAttributes(device, current, payloadType) {
@@ -113,7 +118,7 @@ function extractAttributes(device, current, payloadType) {
                     if (payloadType.toLowerCase() === constants.PAYLOAD_NGSIv2) {
                         valuesEntity.push({
                             name: k,
-                            type: entity[k].type,
+                            type: guessType(k, device, entity[k].type),
                             value: entity[k].value,
                             metadata: entity[k].metadata ? entity[k].metadata : undefined
                         });
@@ -126,7 +131,7 @@ function extractAttributes(device, current, payloadType) {
                             ent.value = entity[k];
                         } else {
                             if (entity[k].type) {
-                                ent.type = entity[k].type;
+                                ent.type = guessType(k, device, entity[k].type);
                                 if (['property', 'geoproperty'].includes(entity[k].type.toLowerCase())) {
                                     ent.value = entity[k].value;
                                 } else if (entity[k].type.toLowerCase() === 'relationship') {
@@ -158,7 +163,7 @@ function extractAttributes(device, current, payloadType) {
             if (current.hasOwnProperty(k)) {
                 values.push({
                     name: k,
-                    type: guessType(k, device),
+                    type: guessType(k, device, null),
                     value: current[k]
                 });
             }
@@ -227,7 +232,7 @@ function singleMeasure(apiKey, deviceId, attribute, device, parsedMessage) {
     const values = [
         {
             name: attribute,
-            type: guessType(attribute, device),
+            type: guessType(attribute, device, null),
             value: parsedMessage[0]
         }
     ];

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
@@ -3,7 +3,10 @@
     "type": "AnMQTTDevice",
     "status": {
         "type": "Property",
-        "value": "free"
+        "value": "free",
+        "metadata": {
+            "observedAt":"2018-09-21T12:00:00Z"
+        }
     },
     "category": {
         "type": "Property",

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
@@ -5,7 +5,9 @@
         "type": "Property",
         "value": "free",
         "metadata": {
-            "observedAt":"2018-09-21T12:00:00Z"
+            "observedAt":{
+              "value": "2018-09-21T12:00:00Z"
+            }
         }
     },
     "category": {

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
@@ -3,7 +3,10 @@
     "type": "AnMQTTDevice",
     "status": {
         "type": "Property",
-        "value": "free"
+        "value": "free",
+        "metadata": {
+            "observedAt":"2012-09-21T12:00:00Z"
+        }
     },
     "category": {
         "type": "Property",

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
@@ -6,8 +6,7 @@
         "value": "free",
         "metadata": {
             "observedAt": {
-                "value": "2012-09-21T12:00:00Z",
-                "type": "??"
+                "value": "2012-09-21T12:00:00Z"
              }
         }
     },

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
@@ -5,7 +5,10 @@
         "type": "Property",
         "value": "free",
         "metadata": {
-            "observedAt":"2012-09-21T12:00:00Z"
+            "observedAt": {
+                "value": "2012-09-21T12:00:00Z",
+                "type": "??"
+             }
         }
     },
     "category": {


### PR DESCRIPTION
Continuation of PR https://github.com/telefonicaid/iotagent-json/pull/779 to add `metadata` for `observedAt`, `createdAt`  and any other stuff found as ngsild attribute properties.