### PR TITLE
Task/include entity id and type as measures when ngsi payload

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Include entity id and entity type as measure value when measure is an ngsi payload

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -113,7 +113,6 @@ function extractAttributes(device, current, payloadType) {
         for (const entity of arrayEntities) {
             const valuesEntity = [];
             for (const k in entity) {
-                // skip id and type
                 if (entity.hasOwnProperty(k)) {
                     if (['id', 'type'].includes(k)) {
                         // Include ngsi id and type as measures

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -117,8 +117,8 @@ function extractAttributes(device, current, payloadType) {
                     if (['id', 'type'].includes(k)) {
                         // Include ngsi id and type as measures
                         valuesEntity.push({
-                            name: payloadType.toLowerCase() + '_' + k,
-                            type: guessType(k, device, entity[k].type),
+                            name: constants.NGSI + k,
+                            type: guessType(k, device, null),
                             value: entity[k]
                         });
                     } else {
@@ -176,6 +176,17 @@ function extractAttributes(device, current, payloadType) {
                 });
             }
         }
+        // Include ngsi id and type as measures
+        values.push({
+            name: constants.NGSI + 'id',
+            type: guessType('name', device, null),
+            value: device['name']
+        });
+        values.push({
+            name: constants.NGSI + 'type',
+            type: guessType('type', device, null),
+            value: device['type']
+        });
     }
     return values;
 }
@@ -252,6 +263,17 @@ function singleMeasure(apiKey, deviceId, attribute, device, parsedMessage) {
             value: parsedMessage[0]
         }
     ];
+    // Include ngsi id and type as measures
+    values.push({
+        name: constants.NGSI + 'id',
+        type: guessType('name', device, null),
+        value: device['name']
+    });
+    values.push({
+        name: constants.NGSI + 'type',
+        type: guessType('type', device, null),
+        value: device['type']
+    });
     config.getLogger().debug(context, 'values updates %s', JSON.stringify(values));
     iotAgentLib.update(device.name, device.type, '', values, device, function (error) {
         if (error) {

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -114,41 +114,50 @@ function extractAttributes(device, current, payloadType) {
             const valuesEntity = [];
             for (const k in entity) {
                 // skip id and type
-                if (entity.hasOwnProperty(k) && !['id', 'type'].includes(k)) {
-                    if (payloadType.toLowerCase() === constants.PAYLOAD_NGSIv2) {
+                if (entity.hasOwnProperty(k)) {
+                    if (['id', 'type'].includes(k)) {
+                        // Include ngsi id and type as measures
                         valuesEntity.push({
-                            name: k,
+                            name: payloadType.toLowerCase() + '_' + k,
                             type: guessType(k, device, entity[k].type),
-                            value: entity[k].value,
-                            metadata: entity[k].metadata ? entity[k].metadata : undefined
+                            value: entity[k].value
                         });
-                    } else if (payloadType.toLowerCase() === constants.PAYLOAD_NGSILD) {
-                        const ent = {
-                            name: k
-                        };
-                        if (k.toLowerCase() === '@context') {
-                            ent.type = '@context';
-                            ent.value = entity[k];
-                        } else {
-                            if (entity[k].type) {
-                                ent.type = guessType(k, device, entity[k].type);
-                                if (['property', 'geoproperty'].includes(entity[k].type.toLowerCase())) {
-                                    ent.value = entity[k].value;
-                                } else if (entity[k].type.toLowerCase() === 'relationship') {
-                                    ent.value = entity[k].object;
-                                }
-                            }
-                            // Add other stuff as metadata
-                            for (const key in entity[k]) {
-                                if (!['type', 'value', 'object'].includes(key.toLowerCase())) {
-                                    if (!ent.metadata) {
-                                        ent.metadata = {};
+                    } else {
+                        if (payloadType.toLowerCase() === constants.PAYLOAD_NGSIv2) {
+                            valuesEntity.push({
+                                name: k,
+                                type: guessType(k, device, entity[k].type),
+                                value: entity[k].value,
+                                metadata: entity[k].metadata ? entity[k].metadata : undefined
+                            });
+                        } else if (payloadType.toLowerCase() === constants.PAYLOAD_NGSILD) {
+                            const ent = {
+                                name: k
+                            };
+                            if (k.toLowerCase() === '@context') {
+                                ent.type = '@context';
+                                ent.value = entity[k];
+                            } else {
+                                if (entity[k].type) {
+                                    ent.type = guessType(k, device, entity[k].type);
+                                    if (['property', 'geoproperty'].includes(entity[k].type.toLowerCase())) {
+                                        ent.value = entity[k].value;
+                                    } else if (entity[k].type.toLowerCase() === 'relationship') {
+                                        ent.value = entity[k].object;
                                     }
-                                    ent.metadata[key] = { value: entity[k][key] };
+                                }
+                                // Add other stuff as metadata
+                                for (const key in entity[k]) {
+                                    if (!['type', 'value', 'object'].includes(key.toLowerCase())) {
+                                        if (!ent.metadata) {
+                                            ent.metadata = {};
+                                        }
+                                        ent.metadata[key] = { value: entity[k][key] };
+                                    }
                                 }
                             }
+                            valuesEntity.push(ent);
                         }
-                        valuesEntity.push(ent);
                     }
                 }
             }

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -119,6 +119,7 @@ function extractAttributes(device, current, payloadType) {
                         // and later in iota-node-lib sendUpdateValueNgsi2 rename as measure_X
                         valuesEntity.push({
                             name: k,
+                            type: guessType(k, device, null),
                             value: entity[k]
                         });
                     } else {

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -176,17 +176,6 @@ function extractAttributes(device, current, payloadType) {
                 });
             }
         }
-        // Include ngsi id and type as measures
-        values.push({
-            name: constants.NGSI + 'id',
-            type: guessType('name', device, null),
-            value: device['name']
-        });
-        values.push({
-            name: constants.NGSI + 'type',
-            type: guessType('type', device, null),
-            value: device['type']
-        });
     }
     return values;
 }
@@ -263,17 +252,6 @@ function singleMeasure(apiKey, deviceId, attribute, device, parsedMessage) {
             value: parsedMessage[0]
         }
     ];
-    // Include ngsi id and type as measures
-    values.push({
-        name: constants.NGSI + 'id',
-        type: guessType('name', device, null),
-        value: device['name']
-    });
-    values.push({
-        name: constants.NGSI + 'type',
-        type: guessType('type', device, null),
-        value: device['type']
-    });
     config.getLogger().debug(context, 'values updates %s', JSON.stringify(values));
     iotAgentLib.update(device.name, device.type, '', values, device, function (error) {
         if (error) {

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -115,10 +115,10 @@ function extractAttributes(device, current, payloadType) {
             for (const k in entity) {
                 if (entity.hasOwnProperty(k)) {
                     if (['id', 'type'].includes(k)) {
-                        // Include ngsi id and type as measures
+                        // Include ngsi id and type as measures by inserting here as is
+                        // and later in iota-node-lib sendUpdateValueNgsi2 rename as measure_X
                         valuesEntity.push({
-                            name: constants.NGSI + k,
-                            type: guessType(k, device, null),
+                            name: k,
                             value: entity[k]
                         });
                     } else {

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -119,7 +119,7 @@ function extractAttributes(device, current, payloadType) {
                         valuesEntity.push({
                             name: payloadType.toLowerCase() + '_' + k,
                             type: guessType(k, device, entity[k].type),
-                            value: entity[k].value
+                            value: entity[k]
                         });
                     } else {
                         if (payloadType.toLowerCase() === constants.PAYLOAD_NGSIv2) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -32,6 +32,7 @@ module.exports = {
 
     PAYLOAD_NGSIv2: 'ngsiv2',
     PAYLOAD_NGSILD: 'ngsild',
+    NGSI: 'ngsi_',
 
     DATE_FORMAT: "yyyymmdd'T'HHMMss'Z'",
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -32,7 +32,6 @@ module.exports = {
 
     PAYLOAD_NGSIv2: 'ngsiv2',
     PAYLOAD_NGSILD: 'ngsild',
-    NGSI: 'ngsi_',
 
     DATE_FORMAT: "yyyymmdd'T'HHMMss'Z'",
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "body-parser-xml": "2.0.5",
     "dateformat": "3.0.3",
     "express": "4.18.1",
-    "iotagent-node-lib": "4.1.0",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
     "logops": "2.1.2",
     "mqtt": "4.3.7",
     "sinon": "~6.1.0",

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
@@ -2,11 +2,9 @@
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
     "measure_id": {
-        "type": "string",
         "value": "urn:ngsi-ld:ParkingSpot:santander:daoiz_velarde_1_5:3"
     },
     "measure_type": {
-        "type": "string",
         "value": "ParkingSpot"
     },
     "status": {

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
@@ -2,9 +2,11 @@
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
     "measure_id": {
+        "type": "string",
         "value": "urn:ngsi-ld:ParkingSpot:santander:daoiz_velarde_1_5:3"
     },
     "measure_type": {
+        "type": "string",
         "value": "ParkingSpot"
     },
     "status": {

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
@@ -1,11 +1,11 @@
 {
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
-    "ngsild_id": {
+    "ngsi_id": {
         "type": "string",
         "value": "urn:ngsi-ld:ParkingSpot:santander:daoiz_velarde_1_5:3"
     },
-    "ngsild_type": {
+    "ngsi_type": {
         "type": "string",
         "value": "ParkingSpot"
     },

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
@@ -1,6 +1,14 @@
 {
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
+    "ngsild_id": {
+        "type": "string",
+        "value": "urn:ngsi-ld:ParkingSpot:santander:daoiz_velarde_1_5:3"
+    },
+    "ngsild_type": {
+        "type": "string",
+        "value": "ParkingSpot"
+    },
     "status": {
         "type": "Property",
         "value": "free",

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure.json
@@ -1,11 +1,11 @@
 {
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
-    "ngsi_id": {
+    "measure_id": {
         "type": "string",
         "value": "urn:ngsi-ld:ParkingSpot:santander:daoiz_velarde_1_5:3"
     },
-    "ngsi_type": {
+    "measure_type": {
         "type": "string",
         "value": "ParkingSpot"
     },

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
@@ -1,11 +1,11 @@
 {
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
-    "ngsi_id": {
+    "measure_id": {
         "type": "string",
         "value": "urn:ngsi-ld:ParkingSpot:santander:reyes_magos_1_1:1"
     },
-    "ngsi_type": {
+    "measure_type": {
         "type": "string",
         "value": "ParkingSpot"
     },

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
@@ -2,9 +2,11 @@
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
     "measure_id": {
+        "type": "string",
         "value": "urn:ngsi-ld:ParkingSpot:santander:reyes_magos_1_1:1"
     },
     "measure_type": {
+        "type": "string",
         "value": "ParkingSpot"
     },
     "status": {

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
@@ -1,6 +1,14 @@
 {
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
+    "ngsild_id": {
+        "type": "string",
+        "value": "urn:ngsi-ld:ParkingSpot:santander:reyes_magos_1_1:1"
+    },
+    "ngsild_type": {
+        "type": "string",
+        "value": "ParkingSpot"
+    },
     "status": {
         "type": "Property",
         "value": "free",

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
@@ -2,11 +2,9 @@
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
     "measure_id": {
-        "type": "string",
         "value": "urn:ngsi-ld:ParkingSpot:santander:reyes_magos_1_1:1"
     },
     "measure_type": {
-        "type": "string",
         "value": "ParkingSpot"
     },
     "status": {

--- a/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsildPayloadMeasure2.json
@@ -1,11 +1,11 @@
 {
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
-    "ngsild_id": {
+    "ngsi_id": {
         "type": "string",
         "value": "urn:ngsi-ld:ParkingSpot:santander:reyes_magos_1_1:1"
     },
-    "ngsild_type": {
+    "ngsi_type": {
         "type": "string",
         "value": "ParkingSpot"
     },

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
@@ -1,11 +1,11 @@
 {
     "id":"Second MQTT Device",
     "type":"AnMQTTDevice",
-    "ngsiv2_id": {
+    "ngsi_id": {
         "type": "string",
         "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2"
     },
-    "ngsiv2_type": {
+    "ngsi_type": {
         "type": "string",
         "value": "Streetlight"
     },

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
@@ -2,11 +2,9 @@
     "id":"Second MQTT Device",
     "type":"AnMQTTDevice",
     "measure_id": {
-        "type": "string",
         "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2"
     },
     "measure_type": {
-        "type": "string",
         "value": "Streetlight"
     },
     "name": {

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
@@ -2,9 +2,11 @@
     "id":"Second MQTT Device",
     "type":"AnMQTTDevice",
     "measure_id": {
+        "type": "string",
         "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2"
     },
     "measure_type": {
+        "type": "string",
         "value": "Streetlight"
     },
     "name": {

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
@@ -1,6 +1,14 @@
 {
     "id":"Second MQTT Device",
-    "type":"AnMQTTDevice",    
+    "type":"AnMQTTDevice",
+    "ngsiv2_id": {
+        "type": "string",
+        "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2"
+    },
+    "ngsiv2_type": {
+        "type": "string",
+        "value": "Streetlight"
+    },
     "name": {
         "type": "Text",
         "value": "MyLightPoint-test1"

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure.json
@@ -1,11 +1,11 @@
 {
     "id":"Second MQTT Device",
     "type":"AnMQTTDevice",
-    "ngsi_id": {
+    "measure_id": {
         "type": "string",
         "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2"
     },
-    "ngsi_type": {
+    "measure_type": {
         "type": "string",
         "value": "Streetlight"
     },

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
@@ -1,11 +1,11 @@
 {
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
-    "ngsiv2_id": {
+    "ngsi_id": {
         "type": "string",
         "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-3"
     },
-    "ngsiv2_type": {
+    "ngsi_type": {
         "type": "string",
         "value": "Streetlight"
     },

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
@@ -2,9 +2,11 @@
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
     "measure_id": {
+        "type": "string",
         "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-3"
     },
     "measure_type": {
+        "type": "string",
         "value": "Streetlight"
     },
     "name": {

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
@@ -1,6 +1,14 @@
 {
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
+    "ngsiv2_id": {
+        "type": "string",
+        "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-3"
+    },
+    "ngsiv2_type": {
+        "type": "string",
+        "value": "Streetlight"
+    },
     "name": {
         "type": "Text",
         "value": "MyLightPoint-test2"

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
@@ -2,11 +2,9 @@
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
     "measure_id": {
-        "type": "string",
         "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-3"
     },
     "measure_type": {
-        "type": "string",
         "value": "Streetlight"
     },
     "name": {

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasure2.json
@@ -1,11 +1,11 @@
 {
     "id": "Second MQTT Device",
     "type": "AnMQTTDevice",
-    "ngsi_id": {
+    "measure_id": {
         "type": "string",
         "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-3"
     },
-    "ngsi_type": {
+    "measure_type": {
         "type": "string",
         "value": "Streetlight"
     },


### PR DESCRIPTION
Continuation of PR https://github.com/telefonicaid/iotagent-json/pull/804




Given a ngsiv2 measure like:
```
curl -i -X POST 'http://localhost:7897/iot/json?i=test1&k=bryippqcmkxc8ncguqxejibts' -d'{
                "actionType": "append",
                "entities": [
                    {
                        "id": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2",
                        "type": "Streetlight",
                        "name": {
                            "type": "Text",
                            "value": "MyLightPoint-test1"
                        }
                    }
                ]
            }' -H 'content-type: application/json'
```
id and type from entity ( "id": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2" and "type": "Streetlight",) are progressing as measures to iotagent using prefix ngsiv2_id and ngsiv2_type respectively:
```
    "measure_id": {
        "type": "string",
        "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2"
    },
    "measure_type": {
        "type": "string",
        "value": "Streetlight"
    },
```
