### PR TITLE
add test about ngsiv2 measure with TimeInstant

### DIFF
--- a/test/unit/ngsiv2/HTTP_receive_ngsiv2_measures-test.js
+++ b/test/unit/ngsiv2/HTTP_receive_ngsiv2_measures-test.js
@@ -398,6 +398,99 @@ describe('HTTP: NGSIv2 Measure reception ', function () {
         });
     });
 
+    describe('When a POST single NGSIv2 entity measure format with a TimeInstant arrives for the HTTP binding and NGSIV2 is the expected payload type', function () {
+        const optionsMeasure = {
+            url: 'http://localhost:' + config.http.port + '/iot/json/',
+            method: 'POST',
+            json: {
+                id: 'urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2',
+                type: 'Streetlight',
+                TimeInstant: {
+                    type: 'DateTime',
+                    value: '2023-11-15T15:52:32Z'
+                },
+                name: {
+                    type: 'Text',
+                    value: 'MyLightPoint-test1'
+                },
+                description: {
+                    type: 'Text',
+                    value: 'testdescription'
+                },
+                status: {
+                    type: 'Text',
+                    value: 'connected',
+                    metadata: {
+                        TimeInstant: {
+                            type: 'DateTime',
+                            value: '2023-11-17T11:59:22.661Z'
+                        }
+                    }
+                },
+                dateServiceStarted: {
+                    type: 'DateTime',
+                    value: '2020-06-04T09: 55: 02'
+                },
+                locationComment: {
+                    type: 'Text',
+                    value: 'Test1'
+                },
+                location: {
+                    type: 'geo:json',
+                    value: {
+                        coordinates: [-87.88429, 41.99499],
+                        type: 'Point'
+                    }
+                },
+                address: {
+                    type: 'Text',
+                    value: {
+                        streetAddress: 'MyStreet'
+                    }
+                },
+                isRemotelyManaged: {
+                    type: 'Integer',
+                    value: 1
+                },
+                installationDate: {
+                    type: 'DateTime',
+                    value: '2022-04-17T02: 30: 04'
+                }
+            },
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            },
+            qs: {
+                i: 'MQTT_2',
+                k: '1234'
+            }
+        };
+        beforeEach(function () {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities?options=upsert',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasureTimeInstant.json')
+                )
+                .reply(204);
+        });
+        it('should return a 200 OK with no error', function (done) {
+            request(optionsMeasure, function (error, result, body) {
+                should.not.exist(error);
+                result.statusCode.should.equal(200);
+                done();
+            });
+        });
+        it('should send its value to the Context Broker', function (done) {
+            request(optionsMeasure, function (error, result, body) {
+                contextBrokerMock.done();
+                done();
+            });
+        });
+    });
+
     describe('When a POST multiple NGSIv2 entity measure format arrives for the HTTP binding and NGSIV2 is the expected payload type', function () {
         const optionsMeasure = {
             url: 'http://localhost:' + config.http.port + '/iot/json/',

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasureTimeInstant.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasureTimeInstant.json
@@ -4,7 +4,7 @@
     "TimeInstant": {
         "type": "DateTime",
         "value": "2023-11-15T15:52:32Z"   
-    }
+    },
     "measure_id": {
         "type": "Text",
         "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2"

--- a/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasureTimeInstant.json
+++ b/test/unit/ngsiv2/contextRequests/ngsiv2PayloadMeasureTimeInstant.json
@@ -1,0 +1,66 @@
+{
+    "id":"Second MQTT Device",
+    "type":"AnMQTTDevice",
+    "TimeInstant": {
+        "type": "DateTime",
+        "value": "2023-11-15T15:52:32Z"   
+    }
+    "measure_id": {
+        "type": "Text",
+        "value": "urn:ngsiv2:Streetlight:Streetlight-Mylightpoint-2"
+    },
+    "measure_type": {
+        "type": "Text",
+        "value": "Streetlight"
+    },
+    "name": {
+        "type": "Text",
+        "value": "MyLightPoint-test1"
+    },
+    "description": {
+        "type": "Text",
+        "value": "testdescription"
+    },
+    "status": {
+        "type": "Text",
+        "value": "connected",
+        "metadata": {
+            "TimeInstant": {
+                "type": "DateTime",
+                "value": "2023-11-17T11:59:22.661Z"
+            }
+        }
+    },
+    "dateServiceStarted": {
+        "type": "DateTime",
+        "value": "2020-06-04T09: 55: 02"
+    },
+    "locationComment": {
+        "type": "Text",
+        "value": "Test1"
+    },
+    "location": {
+        "type": "geo:json",
+        "value": {
+            "coordinates": [
+                -87.88429,
+                41.99499
+            ],
+            "type": "Point"
+        }
+    },
+    "address": {
+        "type": "Text",
+        "value": {
+            "streetAddress": "MyStreet"
+        }
+    },
+    "isRemotelyManaged": {
+        "type": "Integer",
+        "value": 1
+    },
+    "installationDate": {
+        "type": "DateTime",
+        "value": "2022-04-17T02: 30: 04"
+    }
+}


### PR DESCRIPTION
~~related and needs https://github.com/telefonicaid/iotagent-node-lib/pull/1672~~

This example only relies on device/group payloadType, which should be defined as "ngsiv2" for this case as https://github.com/telefonicaid/iotagent-json/blob/b00d69d64b1bb4c431b4e1724b69081b3256803d/test/unit/ngsiv2/deviceProvisioning/provisionDeviceHTTP2.json#L10