### PR TITLE
just print values for that env vars

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Add: X-Processing-Time response header with processing time (in milliseconds) expended by current HTTP measure (iotagent-node-lib#1650)
+- Add: print also IOTA_CONFIG_RETRIEVAL, IOTA_DEFAULT_KEY, IOTA_DEFAULT_TRANSPORT env var values at iotagent startup

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -85,7 +85,10 @@ function processEnvironmentVariables() {
         'IOTA_HTTP_PORT',
         'IOTA_HTTP_TIMEOUT',
         'IOTA_HTTP_KEY',
-        'IOTA_HTTP_CERT'
+        'IOTA_HTTP_CERT',
+        'IOTA_CONFIG_RETRIEVAL',
+        'IOTA_DEFAULT_KEY',
+        'IOTA_DEFAULT_TRANSPORT'
     ];
     const mqttVariables = [
         'IOTA_MQTT_PROTOCOL',
@@ -229,7 +232,7 @@ function processEnvironmentVariables() {
         config.mqtt.clientId = process.env.IOTA_MQTT_CLIENT_ID;
     }
 
-    if (process.env.IOTA_MQTT_DISABLED && process.env.IOTA_MQTT_DISABLED.trim().toLowerCase() === 'true'){
+    if (process.env.IOTA_MQTT_DISABLED && process.env.IOTA_MQTT_DISABLED.trim().toLowerCase() === 'true') {
         config.mqtt.disabled = true;
     }
 
@@ -274,7 +277,7 @@ function processEnvironmentVariables() {
         config.amqp.retryTime = process.env.IOTA_AMQP_RETRY_TIME;
     }
 
-    if (process.env.IOTA_AMQP_DISABLED && process.env.IOTA_AMQP_DISABLED.trim().toLowerCase() === 'true'){
+    if (process.env.IOTA_AMQP_DISABLED && process.env.IOTA_AMQP_DISABLED.trim().toLowerCase() === 'true') {
         config.amqp.disabled = true;
     }
 


### PR DESCRIPTION
The value of the following iotagent env vars were not printed at iotagent startup:

        'IOTA_CONFIG_RETRIEVAL',
        'IOTA_DEFAULT_KEY',
        'IOTA_DEFAULT_TRANSPORT'


Just print them. 
Less than a minor bug.