### PR TITLE
Allow single array MQTT measures of 1 element handed like array

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: Allow single array measures of 1 element handed like array, not single value (#856)
 - Fix: allow send multiple measures in MQTT to CB in a batch (POST /v2/op/update) and sorted by TimeInstant when possible, instead of using multiples single request (#825, iotagent-node-lib#1612) (reopened)
 - Add: allow MQTT single array measures (#856)
 - Fix: check endpoint expression when execute http command

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Fix: Allow single array measures of 1 element handed like array, not single value (#856)
+- Fix: Allow single array MQTT measures of 1 element handed like array, not single value (#856)
 - Fix: allow send multiple measures in MQTT to CB in a batch (POST /v2/op/update) and sorted by TimeInstant when possible, instead of using multiples single request (#825, iotagent-node-lib#1612) (reopened)
 - Add: allow MQTT single array measures (#856)
 - Fix: check endpoint expression when execute http command

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Fix: Allow single array MQTT measures of 1 element handed like array, not single value (#856)
+- Fix: allow single array MQTT measures of 1 element handed like array, not single value (#856)
 - Fix: allow send multiple measures in MQTT to CB in a batch (POST /v2/op/update) and sorted by TimeInstant when possible, instead of using multiples single request (#825, iotagent-node-lib#1612) (reopened)
 - Add: allow MQTT single array measures (#856)
 - Fix: check endpoint expression when execute http command

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,5 @@
+- FIx: Allow single array measures of 1 element handed like array, not single value (#856)
+
 3.6.0 (September 18th, 2024)
 
 - Upgrade body-parser dep from 1.20.0 to 1.20.3

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,3 @@
-- FIx: Allow single array measures of 1 element handed like array, not single value (#856)
-
 3.6.0 (September 18th, 2024)
 
 - Upgrade body-parser dep from 1.20.0 to 1.20.3

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -60,7 +60,12 @@ function parseMessage(message) {
     config.getLogger().debug(context, 'stringMessage: %s parsedMessage: %s', stringMessage, parsedMessage);
     messageArray = [];
     if (Array.isArray(parsedMessage)) {
-        messageArray = parsedMessage;
+        if (parsedMessage.length === 1) {
+            // Allow single array measures of 1 element not handled like single measures
+            messageArray.push(parsedMessage);
+        } else {
+            messageArray = parsedMessage;
+        }
     } else {
         messageArray.push(parsedMessage);
     }

--- a/test/unit/ngsiv2/MQTT_receive_measures-test.js
+++ b/test/unit/ngsiv2/MQTT_receive_measures-test.js
@@ -362,6 +362,36 @@ describe('MQTT: Measure reception ', function () {
         });
     });
 
+    describe('When a new single array measure of 1 element arrives to the MQTT Topic', function () {
+        const values = [{ timestamp: '2025-01-27T09:00:00Z', value: 10.67 }];
+        beforeEach(function () {
+            contextBrokerMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities?options=upsert',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/singleArrayMeasure2.json')
+                )
+                .reply(204);
+        });
+        it('should send its values to the Context Broker', function (done) {
+            mqttClient.publish('/1234/MQTT_2/attrs/temperature', JSON.stringify(values), null, function (error) {
+                setTimeout(function () {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+        it('should send its values to the Context Broker (without leading slash)', function (done) {
+            mqttClient.publish('json/1234/MQTT_2/attrs/temperature', JSON.stringify(values), null, function (error) {
+                setTimeout(function () {
+                    contextBrokerMock.done();
+                    done();
+                }, 100);
+            });
+        });
+    });
+
     describe('When a malformed multiple measure arrives to the MQTT Topic', function () {
         it('should not crash', function (done) {
             mqttClient.publish('/1234/MQTT_2/attrs', '{"humidity": " }(}', null, function (error) {

--- a/test/unit/ngsiv2/contextRequests/singleArrayMeasure2.json
+++ b/test/unit/ngsiv2/contextRequests/singleArrayMeasure2.json
@@ -1,0 +1,13 @@
+{
+    "id":"Second MQTT Device",
+    "type":"AnMQTTDevice",
+    "temperature": {
+        "type": "celsius",
+        "value": [
+            {
+                "timestamp": "2025-01-27T09:00:00Z",
+                "value": 10.67
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Allow single array measures of 1 element not handled like single mesures

Fix for issue https://github.com/telefonicaid/iotagent-json/issues/856#issuecomment-2621436103

- [x] Add test