### PR TITLE
add throtting (by topic) using a topic based queue (MQTT, HTTP, AMQP)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,5 @@
+- Add: throttle based on topic (deviceId + apiKey) for HTTP, MQTT and AMQP bindings, including env vars to configure throttle interval and queue size (#865)
+
 3.7.0 (February 3rd, 2025)
 
 - Add: allow MQTT single array measures (#856)

--- a/config.js
+++ b/config.js
@@ -161,7 +161,7 @@ config.http = {
     /**
      * South Port where the Ultralight transport binding for HTTP will be listening for device requests.
      */
-    port: 7896
+    port: 7896,
     /**
      * HTTP Timeout for the http command endpoint (in miliseconds).
      */
@@ -174,6 +174,16 @@ config.http = {
      * Path to your certificate for HTTPS binding
      */
     // cert: <path_to_cert>
+
+    /**
+     * Time interval to apply throttling (default is 0, no throttling).
+     */
+    throttleInterval: 0,
+
+    /**
+     * Max queue size when throttling interval is upper than 0 (default is 0).
+     */
+    maxQueueSize: 0
 };
 
 config.iota = {

--- a/config.js
+++ b/config.js
@@ -102,7 +102,17 @@ config.mqtt = {
     /**
      * Flag to disable the MQTT transport. (default is false).
      */
-    disabled: false
+    disabled: false,
+
+    /**
+     * Time interval to apply throttling (default is 0, no throttling).
+     */
+    throttleInterval: 0,
+
+    /**
+     * Max queue size when throttling interval is upper than 0 (default is 0).
+     */
+    maxQueueSize: 0
 };
 
 /**
@@ -319,7 +329,7 @@ config.iota = {
 
 /**
  * map {name: function} of extra transformations avaliable at JEXL plugin
-*  see https://github.com/telefonicaid/iotagent-node-lib/tree/master/doc/expressionLanguage.md#available-functions
+ *  see https://github.com/telefonicaid/iotagent-node-lib/tree/master/doc/expressionLanguage.md#available-functions
  */
 
 config.jexlTransformations = {};

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -158,6 +158,8 @@ IoT Agent. The following attributes are accepted:
 -   **durable**: durable queue flag (default is `false`).
 -   **retries**: Number of AMQP connection error retries (default is 5).
 -   **retryTime**: Time between AMQP connection retries (default is 5 seconds).
+-   **throttleInterval**: Time interval to apply throttling (default is 0, no throttling)
+-   **maxQueueSize**: Max queue size when throttling interval is upper than 0 (default is 0)
 
 #### HTTP Binding configuration
 

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -136,8 +136,8 @@ These are the currently available MQTT configuration options:
     order versions) or without the slash. See
     [discussion](https://github.com/telefonicaid/iotagent-node-lib/issues/866).
 -   **clean**: this flag is by default true, set to false to receive QoS 1 and 2 messages while offline.
--   **clientId**: string ID which identifies client in mqtt broker. By default is using a string composed by a fixed prefix 
-    `iotajson_` and a random suffix, i.e. `iotajson_43bf8a3a`.
+-   **clientId**: string ID which identifies client in mqtt broker. By default is using a string composed by a fixed
+    prefix `iotajson_` and a random suffix, i.e. `iotajson_43bf8a3a`.
 
 TLS options (i.e. **ca**, **cert**, **key**, **rejectUnauthorized**) are directly linked with the ones supported by the
 [tls module of Node.js](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options).
@@ -203,6 +203,8 @@ The ones relating specific JSON bindings are described in the following table.
 | IOTA_MQTT_CLEAN               | mqtt.clean              |
 | IOTA_MQTT_CLIENT_ID           | mqtt.clientId           |
 | IOTA_MQTT_DISABLED            | mqtt.disabled           |
+| IOTA_MQTT_THROTTLE_INTERVAL   | mqtt.throttleInterval   |
+| IOTA_MQTT_MAX_QUEUE_SIZE      | mqtt.maxQueueSize       |
 | IOTA_AMQP_HOST                | amqp.host               |
 | IOTA_AMQP_PORT                | amqp.port               |
 | IOTA_AMQP_USERNAME            | amqp.username           |

--- a/docs/installationguide.md
+++ b/docs/installationguide.md
@@ -138,6 +138,8 @@ These are the currently available MQTT configuration options:
 -   **clean**: this flag is by default true, set to false to receive QoS 1 and 2 messages while offline.
 -   **clientId**: string ID which identifies client in mqtt broker. By default is using a string composed by a fixed
     prefix `iotajson_` and a random suffix, i.e. `iotajson_43bf8a3a`.
+-   **throttleInterval**: Time interval to apply throttling (default is 0, no throttling)
+-   **maxQueueSize**: Max queue size when throttling interval is upper than 0 (default is 0)
 
 TLS options (i.e. **ca**, **cert**, **key**, **rejectUnauthorized**) are directly linked with the ones supported by the
 [tls module of Node.js](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options).
@@ -166,6 +168,8 @@ transport protocol binding. The following options are accepted:
 -   **timeout**: HTTP Timeout for the HTTP endpoint (in miliseconds).
 -   **key**: Path to your private key for HTTPS binding
 -   **cert**: Path to your certificate for HTTPS binding
+-   **throttleInterval**: Time interval to apply throttling (default is 0, no throttling)
+-   **maxQueueSize**: Max queue size when throttling interval is upper than 0 (default is 0)
 
 #### Configuration with environment variables
 
@@ -220,6 +224,8 @@ The ones relating specific JSON bindings are described in the following table.
 | IOTA_HTTP_TIMEOUT             | http.timeout            |
 | IOTA_HTTP_KEY                 | http.key                |
 | IOTA_HTTP_CERT                | http.cert               |
+| IOTA_HTTP_THROTTLE_INTERVAL   | http.throttleInterval   |
+| IOTA_HTTP_MAX_QUEUE_SIZE      | http.maxQueueSize       |
 
 (HTTP-related environment variables will be used in the upcoming HTTP binding)
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -879,8 +879,9 @@ transport in command. Default value will be `application/json` but other valids 
 #### Throttling
 
 In order to avoid create duplicated devices when a measure burst arrives for MQTT binding and no provisioned device is
-still created, it is possible to configure a throttling queue for each topic in order to delay deliver a second measure
-for the same topic when is retrieved in a period of time minor tan throttling interval.
+still created, it is possible to configure a throttling queue (through IOTA_MQTT_THROTTLE_INTERVAL and
+IOTA_MQTT_MAX_QUEUE_SIZE) for each topic in order to delay deliver a second measure for the same topic when is retrieved
+in a period of time minor tan throttling interval.
 
 ### AMQP binding
 

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -915,6 +915,13 @@ all the messages must be published to the selected exchange, using the following
 
 The payload is the same as for the other bindings.
 
+#### Throttling
+
+In order to avoid create duplicated devices when a measure burst arrives for AMQP binding and no provisioned device is
+still created, it is possible to configure a throttling queue (through IOTA_AMQP_THROTTLE_INTERVAL and
+IOTA_AMQP_MAX_QUEUE_SIZE) for each topic in order to delay deliver a second measure for the same topic when is retrieved
+in a period of time minor tan throttling interval.
+
 ### Value conversion
 
 The IoTA may perform some ad-hoc conversion for specific types of values, in order to minimize the parsing logic in the

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -533,6 +533,13 @@ current HTTP measure request. For example
 X-Processing-Time: 38
 ```
 
+#### Throttling
+
+In order to avoid create duplicated devices when a measure burst arrives for HTTP binding and no provisioned device is
+still created, it is possible to configure a throttling queue (through IOTA_HTTP_THROTTLE_INTERVAL and
+IOTA_HTTP_MAX_QUEUE_SIZE) for each pair of deviceId and apiKey in order to delay deliver a second measure for the same
+pair of deviceId and apiKey when is retrieved in a period of time minor tan throttling interval.
+
 ### MQTT binding
 
 MQTT binding is based on the existence of a MQTT broker and the usage of different topics to separate the different

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -526,10 +526,11 @@ Content-type: application/json
 
 #### Time processing
 
-HTTP bindig is returning in a HTTP header named `X-Processing-Time` processing time (in milliseconds) expended by current HTTP measure
-request. For example
+HTTP bindig is returning in a HTTP header named `X-Processing-Time` processing time (in milliseconds) expended by
+current HTTP measure request. For example
+
 ```
-X-Processing-Time: 38 
+X-Processing-Time: 38
 ```
 
 ### MQTT binding
@@ -591,9 +592,9 @@ $ mosquitto_pub -t /json/ABCDEF/id_sen1/attrs -m '{"h": 70, "t": 15}' -h <mosqui
 
 Indicating in the topic the name of the attribute to be modified.
 
-In both cases, multiple and single measures, the key is the one provisioned in the IoT Agent through the Configuration API, and the Device ID the ID
-that was provisioned using the Provisioning API. API Key **must** be present, although can be any string in case the
-Device was provisioned without a link to any particular configuration.
+In both cases, multiple and single measures, the key is the one provisioned in the IoT Agent through the Configuration
+API, and the Device ID the ID that was provisioned using the Provisioning API. API Key **must** be present, although can
+be any string in case the Device was provisioned without a link to any particular configuration.
 
 For instance, if using [Mosquitto](https://mosquitto.org/) with a device with ID `id_sen1`, API Key `ABCDEF` and
 attribute IDs `h` and `t`, then humidity measures are reported this way:
@@ -603,9 +604,11 @@ $ mosquitto_pub -t /json/ABCDEF/id_sen1/attrs/h -m 70 -h <mosquitto_broker> -p <
 ```
 
 Also single measure could be an array of measure values like:
+
 ```bash
 $ mosquitto_pub -t /json/ABCDEF/id_sen1/attrs/h -m '[{"timestamp": "2025-01-26T12:00:00Z", "value":44},{"timestamp": "2025-01-27T09:00:00Z", "value":33}]' -h <mosquitto_broker> -p <mosquitto_port> -u <user> -P <password>
 ```
+
 In the single measure case, when the published data is not a valid JSON, it is interpreted as binary content. For
 instance, if the following is published to `/json/ABCDEF/id_sen1/attrs/attrHex` topic:
 
@@ -873,7 +876,13 @@ Moreover a command could define a `contentType` in their definnition with the ai
 transport in command. Default value will be `application/json` but other valids content-type could be: `text/plain`,
 `text/html`, etc
 
-#### AMQP binding
+#### Throttling
+
+In order to avoid create duplicated devices when a measure burst arrives for MQTT binding and no provisioned device is
+still created, it is possible to configure a throttling queue for each topic in order to delay deliver a second measure
+for the same topic when is retrieved in a period of time minor tan throttling interval.
+
+### AMQP binding
 
 [AMQP](https://www.amqp.org/) stands for Advance Message Queuing Protocol, and is one of the most popular protocols for
 message-queue systems. Although the protocol itself is software independent and allows for a great architectural

--- a/lib/bindings/HTTPBinding.js
+++ b/lib/bindings/HTTPBinding.js
@@ -70,6 +70,9 @@ const xml = promisify(
     })
 );
 
+let lastProcessedTime = {};
+const queues = {};
+
 function parserBody() {
     // generic bodyParser
     return function (req, res, next) {
@@ -400,6 +403,50 @@ function handleIncomingMeasure(req, res, next) {
     iotaUtils.retrieveDevice(req.deviceId, req.apiKey, processDeviceMeasure);
 }
 
+function handleIncomingMeasureProxy(req, res, next) {
+    function processQueue(topic) {
+        if (queues[topic] && queues[topic].length > 0) {
+            const now = Date.now();
+            if (now - lastProcessedTime[topic] >= config.getConfig().http.throttleInterval) {
+                var request = queues[topic].shift();
+                request.deviceId = topic.split('/')[0];
+                request.apiKey = topic.split('/')[1];
+                handleIncomingMeasure(request, res, next);
+                lastProcessedTime[topic] = now;
+            }
+        }
+        if (queues[topic].length > 0) {
+            setTimeout(() => processQueue(topic), config.getConfig().http.throttleInterval / 4);
+        }
+    }
+
+    if (!config.getConfig().http.throttleInterval || config.getConfig().http.throttleInterval <= 0) {
+        handleIncomingMeasure(req, res, next);
+    } else {
+        topic = req.deviceId + '/' + req.apiKey;
+        if (!queues[topic]) {
+            queues[topic] = [];
+            lastProcessedTime[topic] = 0;
+        }
+        if (config.getConfig().http.maxQueueSize && queues[topic].length >= config.getConfig().http.maxQueueSize) {
+            config
+                .getLogger()
+                .info(
+                    context,
+                    'discarding measure %s for deviceId + apikey: %s due queue for deviceId + apiKey is full',
+                    message,
+                    topic
+                );
+            return;
+        } else {
+            queues[topic].push(req);
+        }
+        if (queues[topic].length === 1) {
+            setTimeout(() => processQueue(topic), config.getConfig().http.throttleInterval / 4);
+        }
+    }
+}
+
 function isCommand(req, res, next) {
     if (
         req.path ===
@@ -683,7 +730,7 @@ function start(callback) {
         checkMandatoryParams(true),
         parseData,
         addTimestamp,
-        handleIncomingMeasure,
+        handleIncomingMeasureProxy,
         returnCommands
     );
 
@@ -693,7 +740,7 @@ function start(callback) {
         checkMandatoryParams(false),
         parseDataMultipleMeasure,
         addTimestamp,
-        handleIncomingMeasure,
+        handleIncomingMeasureProxy,
         returnCommands
     );
 
@@ -706,7 +753,7 @@ function start(callback) {
         checkMandatoryParams(false),
         parseData, // non multiple measures are expected in this route
         addTimestamp,
-        handleIncomingMeasure,
+        handleIncomingMeasureProxy,
         returnCommands
     );
 
@@ -717,7 +764,7 @@ function start(callback) {
         parseData,
         addTimestamp,
         isCommand,
-        handleIncomingMeasure,
+        handleIncomingMeasureProxy,
         returnCommands
     );
 

--- a/lib/bindings/HTTPBinding.js
+++ b/lib/bindings/HTTPBinding.js
@@ -408,10 +408,11 @@ function handleIncomingMeasureProxy(req, res, next) {
         if (queues[topic] && queues[topic].length > 0) {
             const now = Date.now();
             if (now - lastProcessedTime[topic] >= config.getConfig().http.throttleInterval) {
-                var request = queues[topic].shift();
-                request.deviceId = topic.split('/')[0];
-                request.apiKey = topic.split('/')[1];
-                handleIncomingMeasure(request, res, next);
+                var item = queues[topic].shift();
+                var request = item.req;
+                var response = item.res;
+                var nextf = item.next;
+                handleIncomingMeasure(request, response, nextf);
                 lastProcessedTime[topic] = now;
             }
         }
@@ -433,13 +434,12 @@ function handleIncomingMeasureProxy(req, res, next) {
                 .getLogger()
                 .info(
                     context,
-                    'discarding measure %s for deviceId + apikey: %s due queue for deviceId + apiKey is full',
-                    message,
+                    'discarding measure for deviceId + apikey: %s due queue for deviceId + apiKey is full',
                     topic
                 );
             return;
         } else {
-            queues[topic].push(req);
+            queues[topic].push({ req: req, res: res, next: next });
         }
         if (queues[topic].length === 1) {
             setTimeout(() => processQueue(topic), config.getConfig().http.throttleInterval / 4);

--- a/lib/bindings/HTTPBinding.js
+++ b/lib/bindings/HTTPBinding.js
@@ -424,7 +424,7 @@ function handleIncomingMeasureProxy(req, res, next) {
     if (!config.getConfig().http.throttleInterval || config.getConfig().http.throttleInterval <= 0) {
         handleIncomingMeasure(req, res, next);
     } else {
-        topic = req.deviceId + '/' + req.apiKey;
+        var topic = req.deviceId + '/' + req.apiKey;
         if (!queues[topic]) {
             queues[topic] = [];
             lastProcessedTime[topic] = 0;

--- a/lib/bindings/HTTPBinding.js
+++ b/lib/bindings/HTTPBinding.js
@@ -442,7 +442,7 @@ function handleIncomingMeasureProxy(req, res, next) {
             queues[topic].push({ req: req, res: res, next: next });
         }
         if (queues[topic].length === 1) {
-            setTimeout(() => processQueue(topic), config.getConfig().http.throttleInterval / 4);
+            processQueue(topic);
         }
     }
 }

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -438,10 +438,10 @@ function mqttMessageHandler(topic, message) {
             queues[topic] = [];
             lastProcessedTime[topic] = 0;
         }
-        if (queues[topic].length >= config.getConfig().mqtt.maxQueueSize) {
+        if (config.getConfig().mqtt.maxQueueSize && queues[topic].length >= config.getConfig().mqtt.maxQueueSize) {
             config
                 .getLogger()
-                .info(context, 'discarding measure %s for topic: %s due queue for topic is full', measure, topic);
+                .info(context, 'discarding measure %s for topic: %s due queue for topic is full', message, topic);
             return;
         } else {
             queues[topic].push(message);

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -425,7 +425,7 @@ function amqpMessageHandler(topic, message) {
             queues[topic] = [];
             lastProcessedTime[topic] = 0;
         }
-        if (config.getConfig().amqp.maxQueueSize && queues[amqp].length >= config.getConfig().amqp.maxQueueSize) {
+        if (config.getConfig().amqp.maxQueueSize && queues[topic].length >= config.getConfig().amqp.maxQueueSize) {
             config
                 .getLogger()
                 .info(context, 'discarding measure %s for topic: %s due queue for topic is full', message, topic);

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -434,7 +434,7 @@ function amqpMessageHandler(topic, message) {
             queues[topic].push(message);
         }
         if (queues[topic].length === 1) {
-            setTimeout(() => processQueue(topic), config.getConfig().amqp.throttleInterval / 4);
+            processQueue(topic);
         }
     }
 }
@@ -465,7 +465,7 @@ function mqttMessageHandler(topic, message) {
             queues[topic].push(message);
         }
         if (queues[topic].length === 1) {
-            setTimeout(() => processQueue(topic), config.getConfig().mqtt.throttleInterval / 4);
+            processQueue(topic);
         }
     }
 }

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -42,9 +42,7 @@ let context = {
 const config = require('./configService');
 
 let lastProcessedTime = {};
-const throttleInterval = 50; // 0,05 sec
 const queues = {};
-const MAX_QUEUE_SIZE = 10;
 
 /**
  * Parse a message received from a Topic.
@@ -400,14 +398,14 @@ function messageHandler(topic, message) {
 function processQueue(topic) {
     if (queues[topic] && queues[topic].length > 0) {
         const now = Date.now();
-        if (now - lastProcessedTime[topic] >= throttleInterval) {
+        if (now - lastProcessedTime[topic] >= config.getConfig().mqtt.throttleInterval) {
             const message = queues[topic].shift();
             messageHandler(topic, message);
             lastProcessedTime[topic] = now;
         }
     }
     if (queues[topic].length > 0) {
-        setTimeout(() => processQueue(topic), throttleInterval / 4);
+        setTimeout(() => processQueue(topic), config.getConfig().mqtt.throttleInterval / 4);
     }
 }
 
@@ -433,18 +431,24 @@ function amqpMessageHandler(topic, message) {
 function mqttMessageHandler(topic, message) {
     regenerateTransid(topic);
     config.getLogger().debug(context, 'message topic: %s', topic);
-    if (!queues[topic]) {
-        queues[topic] = [];
-        lastProcessedTime[topic] = 0;
-    }
-    if (queues[topic].length >= MAX_QUEUE_SIZE) {
-        config.getLogger().info(context, 'discarding measure for topic: %s', topic);
-        return;
+    if (!config.getConfig().mqtt.throttleInterval || config.getConfig().mqtt.throttleInterval <= 0) {
+        messageHandler(topic, message);
     } else {
-        queues[topic].push(message);
-    }
-    if (queues[topic].length === 1) {
-        setTimeout(() => processQueue(topic), throttleInterval / 4);
+        if (!queues[topic]) {
+            queues[topic] = [];
+            lastProcessedTime[topic] = 0;
+        }
+        if (queues[topic].length >= config.getConfig().mqtt.maxQueueSize) {
+            config
+                .getLogger()
+                .info(context, 'discarding measure %s for topic: %s due queue for topic is full', measure, topic);
+            return;
+        } else {
+            queues[topic].push(message);
+        }
+        if (queues[topic].length === 1) {
+            setTimeout(() => processQueue(topic), config.getConfig().mqtt.throttleInterval / 4);
+        }
     }
 }
 

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -41,6 +41,11 @@ let context = {
 };
 const config = require('./configService');
 
+let lastProcessedTime = {};
+const throttleInterval = 50; // 0,05 sec
+const queues = {};
+const MAX_QUEUE_SIZE = 10;
+
 /**
  * Parse a message received from a Topic.
  *
@@ -392,6 +397,20 @@ function messageHandler(topic, message) {
     iotaUtils.retrieveDevice(deviceId, apiKey, processDeviceMeasure);
 }
 
+function processQueue(topic) {
+    if (queues[topic] && queues[topic].length > 0) {
+        const now = Date.now();
+        if (now - lastProcessedTime[topic] >= throttleInterval) {
+            const message = queues[topic].shift();
+            messageHandler(topic, message);
+            lastProcessedTime[topic] = now;
+        }
+    }
+    if (queues[topic].length > 0) {
+        setTimeout(() => processQueue(topic), throttleInterval / 4);
+    }
+}
+
 /**
  * Handles an incoming AMQP message, extracting the API Key, device Id and attribute to update (in the case of single
  * measures) from the AMQP topic.
@@ -414,7 +433,19 @@ function amqpMessageHandler(topic, message) {
 function mqttMessageHandler(topic, message) {
     regenerateTransid(topic);
     config.getLogger().debug(context, 'message topic: %s', topic);
-    messageHandler(topic, message);
+    if (!queues[topic]) {
+        queues[topic] = [];
+        lastProcessedTime[topic] = 0;
+    }
+    if (queues[topic].length >= MAX_QUEUE_SIZE) {
+        config.getLogger().info(context, 'discarding measure for topic: %s', topic);
+        return;
+    } else {
+        queues[topic].push(message);
+    }
+    if (queues[topic].length === 1) {
+        setTimeout(() => processQueue(topic), throttleInterval / 4);
+    }
 }
 
 exports.amqpMessageHandler = amqpMessageHandler;

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -421,8 +421,8 @@ function amqpMessageHandler(topic, message) {
     if (!config.getConfig().amqp.throttleInterval || config.getConfig().amqp.throttleInterval <= 0) {
         messageHandler(topic, message);
     } else {
-        if (!queues[amqp]) {
-            queues[amqp] = [];
+        if (!queues[topic]) {
+            queues[topic] = [];
             lastProcessedTime[topic] = 0;
         }
         if (config.getConfig().amqp.maxQueueSize && queues[amqp].length >= config.getConfig().amqp.maxQueueSize) {

--- a/lib/commonBindings.js
+++ b/lib/commonBindings.js
@@ -418,7 +418,25 @@ function processQueue(topic) {
  */
 function amqpMessageHandler(topic, message) {
     regenerateTransid(topic);
-    messageHandler(topic, message);
+    if (!config.getConfig().amqp.throttleInterval || config.getConfig().amqp.throttleInterval <= 0) {
+        messageHandler(topic, message);
+    } else {
+        if (!queues[amqp]) {
+            queues[amqp] = [];
+            lastProcessedTime[topic] = 0;
+        }
+        if (config.getConfig().amqp.maxQueueSize && queues[amqp].length >= config.getConfig().amqp.maxQueueSize) {
+            config
+                .getLogger()
+                .info(context, 'discarding measure %s for topic: %s due queue for topic is full', message, topic);
+            return;
+        } else {
+            queues[topic].push(message);
+        }
+        if (queues[topic].length === 1) {
+            setTimeout(() => processQueue(topic), config.getConfig().amqp.throttleInterval / 4);
+        }
+    }
 }
 
 /**

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -83,6 +83,8 @@ function processEnvironmentVariables() {
         'IOTA_AMQP_RETRIES',
         'IOTA_AMQP_RETRY_TIME',
         'IOTA_AMQP_DISABLED',
+        'IOTA_AMQP_THROTTLE_INTERVAL',
+        'IOTA_AMQP_MAX_QUEUE_SIZE',
         'IOTA_HTTP_HOST',
         'IOTA_HTTP_PORT',
         'IOTA_HTTP_TIMEOUT',
@@ -127,7 +129,9 @@ function processEnvironmentVariables() {
         'IOTA_AMQP_DURABLE',
         'IOTA_AMQP_RETRIES',
         'IOTA_AMQP_RETRY_TIME',
-        'IOTA_AMQP_DISABLED'
+        'IOTA_AMQP_DISABLED',
+        'IOTA_AMQP_THROTTLE_INTERVAL',
+        'IOTA_AMQP_MAX_QUEUE_SIZE'
     ];
     const httpVariables = [
         'IOTA_HTTP_HOST',
@@ -302,6 +306,14 @@ function processEnvironmentVariables() {
 
     if (process.env.IOTA_AMQP_DISABLED && process.env.IOTA_AMQP_DISABLED.trim().toLowerCase() === 'true') {
         config.amqp.disabled = true;
+    }
+
+    if (process.env.IOTA_AMQP_THROTTLE_INTERVAL) {
+        config.amqp.throttleInterval = process.env.IOTA_AMQP_THROTTLE_INTERVAL;
+    }
+
+    if (process.env.IOTA_AMQP_MAX_QUEUE_SIZE) {
+        config.amqp.maxQueueSize = process.env.IOTA_AMQP_MAX_QUEUE_SIZE;
     }
 
     if (anyIsSet(httpVariables)) {

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -90,6 +90,7 @@ function processEnvironmentVariables() {
         'IOTA_HTTP_CERT',
         'IOTA_HTTP_DISABLED',
         'IOTA_HTTP_THROTTLE_INTERVAL',
+        'IOTA_HTTP_MAX_QUEUE_SIZE',
         'IOTA_CONFIG_RETRIEVAL',
         'IOTA_DEFAULT_KEY',
         'IOTA_DEFAULT_TRANSPORT'
@@ -134,8 +135,8 @@ function processEnvironmentVariables() {
         'IOTA_HTTP_TIMEOUT',
         'IOTA_HTTP_KEY',
         'IOTA_HTTP_CERT',
-        'IOTA_MQTT_THROTTLE_INTERVAL',
-        'IOTA_MQTT_MAX_QUEUE_SIZE'
+        'IOTA_HTTP_THROTTLE_INTERVAL',
+        'IOTA_HTTP_MAX_QUEUE_SIZE'
     ];
 
     const protectedVariables = [
@@ -330,7 +331,7 @@ function processEnvironmentVariables() {
     }
 
     if (process.env.IOTA_HTTP_THROTTLE_INTERVAL) {
-        config.http.throttleInterval = process.env.IOTA_MQTT_THROTTLE_INTERVAL;
+        config.http.throttleInterval = process.env.IOTA_HTTP_THROTTLE_INTERVAL;
     }
 
     if (process.env.IOTA_HTTP_MAX_QUEUE_SIZE) {

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -71,6 +71,8 @@ function processEnvironmentVariables() {
         'IOTA_MQTT_CLEAN',
         'IOTA_MQTT_CLIENT_ID',
         'IOTA_MQTT_DISABLED',
+        'IOTA_MQTT_THROTTLE_INTERVAL',
+        'IOTA_MQTT_MAX_QUEUE_SIZE',
         'IOTA_AMQP_HOST',
         'IOTA_AMQP_PORT',
         'IOTA_AMQP_USERNAME',
@@ -108,7 +110,9 @@ function processEnvironmentVariables() {
         'IOTA_MQTT_AVOID_LEADING_SLASH',
         'IOTA_MQTT_CLEAN',
         'IOTA_MQTT_CLIENT_ID',
-        'IOTA_MQTT_DISABLED'
+        'IOTA_MQTT_DISABLED',
+        'IOTA_MQTT_THROTTLE_INTERVAL',
+        'IOTA_MQTT_MAX_QUEUE_SIZE'
     ];
     const amqpVariables = [
         'IOTA_AMQP_HOST',
@@ -234,6 +238,14 @@ function processEnvironmentVariables() {
 
     if (process.env.IOTA_MQTT_DISABLED && process.env.IOTA_MQTT_DISABLED.trim().toLowerCase() === 'true') {
         config.mqtt.disabled = true;
+    }
+
+    if (process.env.IOTA_MQTT_THROTTLE_INTERVAL) {
+        config.mqtt.throttleInterval = process.env.IOTA_MQTT_THROTTLE_INTERVAL;
+    }
+
+    if (process.env.IOTA_MQTT_MAX_QUEUE_SIZE) {
+        config.mqtt.maxQueueSize = process.env.IOTA_MQTT_MAX_QUEUE_SIZE;
     }
 
     if (anyIsSet(amqpVariables)) {

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -88,6 +88,8 @@ function processEnvironmentVariables() {
         'IOTA_HTTP_TIMEOUT',
         'IOTA_HTTP_KEY',
         'IOTA_HTTP_CERT',
+        'IOTA_HTTP_DISABLED',
+        'IOTA_HTTP_THROTTLE_INTERVAL',
         'IOTA_CONFIG_RETRIEVAL',
         'IOTA_DEFAULT_KEY',
         'IOTA_DEFAULT_TRANSPORT'
@@ -126,7 +128,15 @@ function processEnvironmentVariables() {
         'IOTA_AMQP_RETRY_TIME',
         'IOTA_AMQP_DISABLED'
     ];
-    const httpVariables = ['IOTA_HTTP_HOST', 'IOTA_HTTP_PORT', 'IOTA_HTTP_TIMEOUT', 'IOTA_HTTP_KEY', 'IOTA_HTTP_CERT'];
+    const httpVariables = [
+        'IOTA_HTTP_HOST',
+        'IOTA_HTTP_PORT',
+        'IOTA_HTTP_TIMEOUT',
+        'IOTA_HTTP_KEY',
+        'IOTA_HTTP_CERT',
+        'IOTA_MQTT_THROTTLE_INTERVAL',
+        'IOTA_MQTT_MAX_QUEUE_SIZE'
+    ];
 
     const protectedVariables = [
         'IOTA_MQTT_KEY',
@@ -317,6 +327,14 @@ function processEnvironmentVariables() {
     if (process.env.IOTA_HTTP_CERT) {
         fileExists(process.env.IOTA_HTTP_KEY);
         config.http.cert = process.env.IOTA_HTTP_CERT;
+    }
+
+    if (process.env.IOTA_HTTP_THROTTLE_INTERVAL) {
+        config.http.throttleInterval = process.env.IOTA_MQTT_THROTTLE_INTERVAL;
+    }
+
+    if (process.env.IOTA_HTTP_MAX_QUEUE_SIZE) {
+        config.http.maxQueueSize = process.env.IOTA_HTTP_MAX_QUEUE_SIZE;
     }
 }
 

--- a/test/unit/ngsiv2/AMQP_receive_burst-test.js
+++ b/test/unit/ngsiv2/AMQP_receive_burst-test.js
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-json
+ *
+ * iotagent-json is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-json is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-json.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+
+/* eslint-disable no-unused-vars */
+
+const iotaJson = require('../../../');
+const config = require('./config-test2.js');
+const nock = require('nock');
+const iotAgentLib = require('iotagent-node-lib');
+const should = require('should');
+const async = require('async');
+const amqp = require('amqplib/callback_api');
+const utils = require('../../utils');
+const request = utils.request;
+
+const context = {
+    op: 'IoTAgentNGSI.Request'
+};
+
+let amqpConn;
+let channel;
+
+function startConnection(exchange, callback) {
+    amqp.connect('amqp://localhost', function (err, conn) {
+        amqpConn = conn;
+
+        conn.createChannel(function (err, ch) {
+            ch.assertExchange(exchange, 'topic', {});
+
+            channel = ch;
+            callback(err);
+        });
+    });
+}
+
+function parallelPub(topic, valuesMeasure1, valuesMeasure2, callback) {
+    channel.publish(config.amqp.exchange, topic, Buffer.from(JSON.stringify(valuesMeasure1)));
+    channel.publish(config.amqp.exchange, topic, Buffer.from(JSON.stringify(valuesMeasure2)));
+    callback(null);
+}
+
+const groupCreation = {
+    url: 'http://localhost:' + config.iota.server.port + '/iot/services',
+    method: 'POST',
+    json: {
+        services: [
+            {
+                resource: '/iot/json',
+                apikey: 'KL223HHV8732SFL2',
+                entity_type: 'TheLightType',
+                cbHost: 'http://192.168.1.1:1026',
+                commands: [],
+                lazy: [],
+                attributes: [
+                    {
+                        name: 'status',
+                        type: 'Boolean'
+                    }
+                ],
+                static_attributes: []
+            }
+        ]
+    },
+    headers: {
+        'fiware-service': 'smartgondor',
+        'fiware-servicepath': '/gardens'
+    }
+};
+
+let contextBrokerMock;
+let contextBrokerUnprovMock;
+
+describe('AMQP: Measure reception ', function () {
+    beforeEach(function (done) {
+        nock.cleanAll();
+
+        // This mock does not check the payload since the aim of the test is not to verify
+        // device provisioning functionality. Appropriate verification is done in tests under
+        // provisioning folder of iotagent-node-lib
+        contextBrokerMock = nock('http://192.168.1.1:1026');
+
+        iotaJson.start(config, function () {
+            //done();
+            startConnection(config.amqp.exchange, function () {
+                done();
+            });
+        });
+    });
+
+    afterEach(function (done) {
+        nock.cleanAll();
+        amqpConn.close();
+        async.series([iotAgentLib.clearAll, iotaJson.stop], done);
+    });
+
+    describe('When a burst of measures arrives for an unprovisioned device', function () {
+        const valuesMeasure = {
+            humidity: '32',
+            temperature: '87'
+        };
+        const valuesMeasure2 = {
+            humidity: '12',
+            temperature: '17'
+        };
+        // This mock does not check the payload since the aim of the test is not to verify
+        // device provisioning functionality. Appropriate verification is done in tests under
+        // provisioning folder of iotagent-node-lib
+        beforeEach(function (done) {
+            contextBrokerUnprovMock = nock('http://192.168.1.1:1026');
+
+            contextBrokerUnprovMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities?options=upsert',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/unprovisionedMeasureBurst.json')
+                )
+                .reply(204);
+
+            contextBrokerUnprovMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities?options=upsert',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/unprovisionedMeasureBurstDup.json')
+                )
+                .reply(204);
+
+            request(groupCreation, function (error, response, body) {
+                done();
+            });
+        });
+
+        it('should not duplicate registered devices', function (done) {
+            const getDeviceOptions = {
+                url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+                method: 'GET',
+                headers: {
+                    'fiware-service': 'smartgondor',
+                    'fiware-servicepath': '/gardens'
+                },
+                qs: {
+                    i: 'JSON_UNPROVISIONED2',
+                    k: 'KL223HHV8732SFL2'
+                }
+            };
+
+            parallelPub('.KL223HHV8732SFL2.JSON_UNPROVISIONED2.attrs', valuesMeasure, valuesMeasure2, function (error) {
+                setTimeout(function () {
+                    request(getDeviceOptions, function (error, response, body) {
+                        should.not.exist(error);
+                        response.statusCode.should.equal(200);
+                        body.devices.length.should.equal(1);
+                        contextBrokerUnprovMock.done();
+                        done();
+                    });
+                }, 100);
+            });
+        });
+    });
+});

--- a/test/unit/ngsiv2/HTTP_receive_burst-test.js
+++ b/test/unit/ngsiv2/HTTP_receive_burst-test.js
@@ -134,16 +134,6 @@ let contextBrokerUnprovMock;
 
 describe('HTTP: Measure reception ', function () {
     beforeEach(function (done) {
-        // const provisionOptions = {
-        //     url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
-        //     method: 'POST',
-        //     json: utils.readExampleFile('./test/unit/ngsiv2/deviceProvisioning/provisionDeviceHTTP.json'),
-        //     headers: {
-        //         'fiware-service': 'smartgondor',
-        //         'fiware-servicepath': '/gardens'
-        //     }
-        // };
-
         nock.cleanAll();
 
         // This mock does not check the payload since the aim of the test is not to verify
@@ -152,9 +142,6 @@ describe('HTTP: Measure reception ', function () {
         contextBrokerMock = nock('http://192.168.1.1:1026');
 
         iotaJson.start(config, function () {
-            // request(provisionOptions, function (error, response, body) {
-            //     done();
-            // });
             done();
         });
     });
@@ -245,7 +232,6 @@ describe('HTTP: Measure reception ', function () {
                 request(getDeviceOptions, function (error, response, body) {
                     should.not.exist(error);
                     response.statusCode.should.equal(200);
-                    console.log('devices: ' + JSON.stringify(body));
                     body.devices.length.should.equal(1);
                     contextBrokerUnprovMock.done();
                     done();

--- a/test/unit/ngsiv2/HTTP_receive_burst-test.js
+++ b/test/unit/ngsiv2/HTTP_receive_burst-test.js
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2016 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-json
+ *
+ * iotagent-json is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-json is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-json.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+
+/* eslint-disable no-unused-vars */
+
+const iotaJson = require('../../../');
+const config = require('./config-test2.js');
+const nock = require('nock');
+const iotAgentLib = require('iotagent-node-lib');
+const should = require('should');
+const async = require('async');
+
+const utils = require('../../utils');
+const request = utils.request;
+
+const got = require('got');
+const logger = require('logops');
+const context = {
+    op: 'IoTAgentNGSI.Request'
+};
+const util = require('util');
+
+function getOptions(options) {
+    const httpOptions = {
+        method: options.method,
+        searchParams: options.searchParams || options.qs,
+        headers: options.headers,
+        throwHttpErrors: options.throwHttpErrors || false,
+        retry: options.retry || 0,
+        responseType: options.responseType || 'json'
+    };
+
+    // got library is not properly documented, so it is not clear which takes precedence
+    // among body, json and form (see https://stackoverflow.com/q/70754880/1485926).
+    // Thus, we are enforcing our own precedence with the "else if" chain below.
+    // Behaviour is consistent with the one described at development.md#iotagentlibrequest
+
+    if (options.method === 'GET' || options.method === 'HEAD' || options.method === 'OPTIONS') {
+        // Do nothing - Never add a body
+    } else if (options.body) {
+        // body takes precedence over json or form
+        httpOptions.body = options.body;
+    } else if (options.json) {
+        // json takes precedence over form
+        httpOptions.json = options.json;
+    } else if (options.form) {
+        // Note that we don't consider 'form' part of the function API (check development.md#iotagentlibrequest)
+        // but we are preparing the code anyway as a safe measure
+        httpOptions.form = options.form;
+    }
+
+    return httpOptions;
+}
+
+function paralelRequest(options, options2, callback) {
+    const httpOptions = getOptions(options);
+    const httpOptions2 = getOptions(options2);
+
+    got(options2.url || options2.uri, httpOptions2)
+        .then((response) => {
+            logger.debug(context, 'Response %s', JSON.stringify(response.body, null, 4));
+            // nothing to do
+        })
+        .catch((error) => {
+            logger.debug(context, 'Error: %s', JSON.stringify(util.inspect(error), null, 4));
+            // nothing to do
+        });
+
+    got(options.url || options.uri, httpOptions)
+        .then((response) => {
+            logger.debug(context, 'Response %s', JSON.stringify(response.body, null, 4));
+            return callback(null, response, response.body);
+        })
+        .catch((error) => {
+            logger.debug(context, 'Error: %s', JSON.stringify(util.inspect(error), null, 4));
+            return callback(error);
+        });
+}
+
+const groupCreation = {
+    url: 'http://localhost:' + config.iota.server.port + '/iot/services',
+    method: 'POST',
+    json: {
+        services: [
+            {
+                resource: '/iot/json',
+                apikey: 'KL223HHV8732SFL2',
+                entity_type: 'TheLightType',
+                trust: '8970A9078A803H3BL98PINEQRW8342HBAMS',
+                cbHost: 'http://192.168.1.1:1026',
+                storeLastMeasure: true,
+                commands: [],
+                lazy: [],
+                attributes: [
+                    {
+                        name: 'status',
+                        type: 'Boolean'
+                    }
+                ],
+                static_attributes: []
+            }
+        ]
+    },
+    headers: {
+        'fiware-service': 'smartgondor',
+        'fiware-servicepath': '/gardens'
+    }
+};
+
+let contextBrokerMock;
+let contextBrokerUnprovMock;
+
+describe('HTTP: Measure reception ', function () {
+    beforeEach(function (done) {
+        // const provisionOptions = {
+        //     url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+        //     method: 'POST',
+        //     json: utils.readExampleFile('./test/unit/ngsiv2/deviceProvisioning/provisionDeviceHTTP.json'),
+        //     headers: {
+        //         'fiware-service': 'smartgondor',
+        //         'fiware-servicepath': '/gardens'
+        //     }
+        // };
+
+        nock.cleanAll();
+
+        // This mock does not check the payload since the aim of the test is not to verify
+        // device provisioning functionality. Appropriate verification is done in tests under
+        // provisioning folder of iotagent-node-lib
+        contextBrokerMock = nock('http://192.168.1.1:1026');
+
+        iotaJson.start(config, function () {
+            // request(provisionOptions, function (error, response, body) {
+            //     done();
+            // });
+            done();
+        });
+    });
+
+    afterEach(function (done) {
+        nock.cleanAll();
+
+        async.series([iotAgentLib.clearAll, iotaJson.stop], done);
+    });
+
+    describe('When a burst of measures arrives for an unprovisioned device', function () {
+        const optionsMeasure = {
+            url: 'http://localhost:' + config.http.port + '/iot/json',
+            method: 'POST',
+            json: {
+                humidity: '32',
+                temperature: '87'
+            },
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            },
+            qs: {
+                i: 'JSON_UNPROVISIONED2',
+                k: 'KL223HHV8732SFL2'
+            }
+        };
+        const optionsMeasure2 = {
+            url: 'http://localhost:' + config.http.port + '/iot/json',
+            method: 'POST',
+            json: {
+                humidity: '12',
+                temperature: '17'
+            },
+            headers: {
+                'fiware-service': 'smartgondor',
+                'fiware-servicepath': '/gardens'
+            },
+            qs: {
+                i: 'JSON_UNPROVISIONED2',
+                k: 'KL223HHV8732SFL2'
+            }
+        };
+        // This mock does not check the payload since the aim of the test is not to verify
+        // device provisioning functionality. Appropriate verification is done in tests under
+        // provisioning folder of iotagent-node-lib
+        beforeEach(function (done) {
+            contextBrokerUnprovMock = nock('http://192.168.1.1:1026');
+
+            contextBrokerUnprovMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities?options=upsert',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/unprovisionedMeasureBurst.json')
+                )
+                .reply(204);
+
+            contextBrokerUnprovMock
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', '/gardens')
+                .post(
+                    '/v2/entities?options=upsert',
+                    utils.readExampleFile('./test/unit/ngsiv2/contextRequests/unprovisionedMeasureBurstDup.json')
+                )
+                .reply(204);
+
+            request(groupCreation, function (error, response, body) {
+                done();
+            });
+        });
+
+        it('should duplicate registered devices', function (done) {
+            const getDeviceOptions = {
+                url: 'http://localhost:' + config.iota.server.port + '/iot/devices',
+                method: 'GET',
+                headers: {
+                    'fiware-service': 'smartgondor',
+                    'fiware-servicepath': '/gardens'
+                },
+                qs: {
+                    i: 'JSON_UNPROVISIONED2',
+                    k: 'KL223HHV8732SFL2'
+                }
+            };
+
+            paralelRequest(optionsMeasure2, optionsMeasure, function (error, response, body) {
+                request(getDeviceOptions, function (error, response, body) {
+                    should.not.exist(error);
+                    response.statusCode.should.equal(200);
+                    console.log('devices: ' + JSON.stringify(body));
+                    body.devices.length.should.equal(1);
+                    contextBrokerUnprovMock.done();
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/test/unit/ngsiv2/config-test2.js
+++ b/test/unit/ngsiv2/config-test2.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of iotagent-json
+ *
+ * iotagent-json is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * iotagent-json is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with iotagent-json.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+
+/* eslint-disable no-unused-vars */
+
+const config = {};
+
+config.mqtt = {
+    host: 'localhost',
+    port: 1883,
+    throttleInterval: 50,
+    maxQueueSize: 100
+};
+
+config.http = {
+    port: 7896,
+    host: 'localhost',
+    throttleInterval: 50,
+    maxQueueSize: 100
+};
+
+config.amqp = {
+    port: 5672,
+    exchange: 'amq.topic',
+    queue: 'iota_queue',
+    options: { durable: true }
+};
+
+config.iota = {
+    logLevel: 'DEBUG',
+    contextBroker: {
+        host: '192.168.1.1',
+        port: '1026',
+        ngsiVersion: 'v2'
+    },
+    server: {
+        port: 4041,
+        host: 'localhost'
+    },
+    deviceRegistry: {
+        type: 'mongodb'
+    },
+    mongodb: {
+        host: 'localhost',
+        port: '27017',
+        db: 'iotagent'
+    },
+    types: {},
+    service: 'howtoservice',
+    subservice: '/howto',
+    providerUrl: 'http://localhost:4041',
+    deviceRegistrationDuration: 'P1M',
+    defaultType: 'Thing',
+    defaultResource: '/iot/json',
+    compressTimestamp: true
+};
+
+config.defaultKey = '1234';
+config.defaultTransport = 'HTTP';
+
+module.exports = config;

--- a/test/unit/ngsiv2/contextRequests/unprovisionedMeasureBurst.json
+++ b/test/unit/ngsiv2/contextRequests/unprovisionedMeasureBurst.json
@@ -1,0 +1,12 @@
+{
+  "id":"TheLightType:JSON_UNPROVISIONED2",
+  "type":"TheLightType",
+  "humidity":{
+    "type": "Text",
+    "value": "32"    
+  },
+  "temperature":{
+    "type": "Text",
+    "value": "87"    
+  }
+}

--- a/test/unit/ngsiv2/contextRequests/unprovisionedMeasureBurstDup.json
+++ b/test/unit/ngsiv2/contextRequests/unprovisionedMeasureBurstDup.json
@@ -1,0 +1,12 @@
+{
+  "id":"TheLightType:JSON_UNPROVISIONED2",
+  "type":"TheLightType",
+  "humidity":{
+    "type": "Text",
+    "value": "12"    
+  },
+  "temperature":{
+    "type": "Text",
+    "value": "17"    
+  }
+}


### PR DESCRIPTION
Related https://github.com/telefonicaid/iotagent-json/issues/865
This PR adds to MQTT and HTTP binding a throttle based queue for each topic.

- [x] Tested
- [x] Configurable env vars: queue size, throttleInterval
- [x] Doc
- [x] MQTT
- [x] HTTP
- [x] AMQP
- [x] Add Test for HTTP burst
- [x] Add Test for MQTT burst
- [x] Add Test for AMQP burst
- [ ] Allow to use bull/redis for queue if configured
